### PR TITLE
test: add unit tests for admin login view

### DIFF
--- a/tests/unit/test_auth_views.py
+++ b/tests/unit/test_auth_views.py
@@ -1,9 +1,11 @@
 import pytest
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
+from django.urls import reverse
 
 
 REGISTER_URL = "/auth/register/"
+ADMINLOGIN_URL = "/auth/admin-login/"
 
 
 def _valid_post_data(**overrides):
@@ -12,6 +14,15 @@ def _valid_post_data(**overrides):
         "email": "test@example.com",
         "password": "securePass1",
         "password2": "securePass1",
+    }
+    data.update(overrides)
+    return data
+
+
+def _valid_admin_data(**overrides):
+    data = {
+        "username": "superuser",
+        "password": "superPass1",
     }
     data.update(overrides)
     return data
@@ -74,5 +85,48 @@ class TestRegisterView:
         response = client.post(REGISTER_URL, data)
         assert response.status_code == 302
         assert response.url == "/auth/register/"
+        msgs = list(get_messages(response.wsgi_request))
+        assert any(m.level_tag == "error" for m in msgs)
+
+
+@pytest.mark.django_db
+class TestAdminLoginView:
+    def test_unauthenticated_get_renders_form(self, client):
+        response = client.get(ADMINLOGIN_URL)
+        assert response.status_code == 200
+        assert "authentication/adminlogin.html" in [t.name for t in response.templates]
+
+    def test_authenticated_superuser_get_redirects_to_admin(self, client):
+        # Documents TRI-27: currently broken (missing return on line 85 of auth/views.py)
+        user = User.objects.create_superuser(**_valid_admin_data())
+        client.force_login(user)
+        response = client.get(ADMINLOGIN_URL)
+        assert response.status_code == 302
+        assert response.url == reverse("adminMainPage")
+
+    def test_authenticated_non_superuser_get_redirects_to_mainpage(self, client):
+        user = User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
+        client.force_login(user)
+        response = client.get(ADMINLOGIN_URL)
+        assert response.status_code == 302
+        assert response.url == reverse("mainpage")
+
+    def test_post_valid_superuser_credentials_redirects_to_admin(self, client):
+        User.objects.create_superuser(**_valid_admin_data())
+        response = client.post(ADMINLOGIN_URL, _valid_admin_data())
+        assert response.status_code == 302
+        assert response.url == reverse("adminMainPage")
+
+    def test_post_valid_non_superuser_credentials_redirects_to_mainpage(self, client):
+        User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
+        response = client.post(ADMINLOGIN_URL, _valid_admin_data(username="regularuser", password="userPass1"))
+        assert response.status_code == 302
+        assert response.url == reverse("mainpage")
+
+    def test_post_invalid_credentials_redirects_with_error(self, client):
+        User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
+        response = client.post(ADMINLOGIN_URL, _valid_admin_data(username="regularuser", password="wrongpass"))
+        assert response.status_code == 302
+        assert response.url == reverse("adminLogin")
         msgs = list(get_messages(response.wsgi_request))
         assert any(m.level_tag == "error" for m in msgs)


### PR DESCRIPTION
Fixes TRI-63

### Description

Adds integration tests for the `adminlogin` view covering six authentication states:
- Unauthenticated GET renders the login form
- Authenticated superuser GET redirects to admin panel
- Authenticated non-superuser GET redirects to main page
- POST with valid superuser credentials redirects to admin panel
- POST with valid non-superuser credentials redirects to main page
- POST with invalid credentials redirects back with an error message

Also introduces `_valid_admin_data(**overrides)` helper to reduce credential repetition across tests, and documents the TRI-27 bug (missing `return` on line 85 of `auth/views.py`) inline.

### Tests

Added `TestAdminLoginView` (6 tests) to `tests/unit/test_auth_views.py`. Run with:

```bash
source .env && uv run pytest tests/unit/test_auth_views.py -v
```

Note: `test_authenticated_superuser_get_redirects_to_admin` will fail until TRI-27 is resolved.