### PR TITLE
fix: add return before redirect in adminlogin superuser path

### DIFF
--- a/auth/views.py
+++ b/auth/views.py
@@ -82,7 +82,7 @@ def logout(request):
 def adminlogin(request):
     if request.user.is_authenticated:
         if request.user.is_superuser:
-            redirect("admin_page")
+            return redirect("adminMainPage")
         else:
             return redirect("mainpage")
 


### PR DESCRIPTION
Fixes #TRI-27

### Description

`auth/views.py:85` called `redirect("admin_page")` without `return`, so the redirect response was discarded and execution fell through to render the login form instead. Additionally, the URL name `"admin_page"` did not exist — the correct name is `"adminMainPage"`.

Fixed by changing the line to `return redirect("adminMainPage")`.

### Tests

Existing unit tests in `tests/unit/test_auth_views.py::TestAdminLoginView` cover all three acceptance criteria:

- Authenticated superuser GET → 302 to admin panel (`test_authenticated_superuser_get_redirects_to_admin`) — was failing, now passes
- Authenticated non-superuser GET → 302 to mainpage — already passed
- Unauthenticated GET → 200 login form — already passed

All 6 tests in `TestAdminLoginView` pass.