### PR TITLE
test: cover custom admin panel

### DIFF
--- a/adminpanel/forms.py
+++ b/adminpanel/forms.py
@@ -14,17 +14,13 @@ class ModifiedModelForm(ModelForm):
 
     @cached_property
     def changed_data(self):
-        apparent_changed_data = [
-            name for name, bf in self._bound_items() if bf._has_changed()
-        ]
-        if self._newly_created or not self.has_changed:
+        apparent_changed_data = super().changed_data
+        if self._newly_created or not hasattr(self, "cleaned_data"):
             return apparent_changed_data
-        objectInstance = self.instance
         model = self._meta.model
         actual_changed_fields = list()
         differenceBetweenFields = [
-            (getattr(objectInstance, x), self.cleaned_data[x])
-            for x in apparent_changed_data
+            (self.initial.get(x), self.cleaned_data[x]) for x in apparent_changed_data
         ]
         for idx in range(len(apparent_changed_data)):
             field = apparent_changed_data[idx]
@@ -64,7 +60,7 @@ class ModifiedModelForm(ModelForm):
             return objectInstance
         else:
             objectInstance = self.instance
-            if self.has_changed:
+            if self.has_changed():
                 changed_fields = self.changed_data
                 differenceBetweenFields = [self.cleaned_data[x] for x in changed_fields]
                 for idx in range(len(changed_fields)):
@@ -74,6 +70,7 @@ class ModifiedModelForm(ModelForm):
                         getattr(objectInstance, field).set(newData)
                     else:
                         setattr(objectInstance, field, newData)
+                objectInstance.save()
             return objectInstance
 
 

--- a/adminpanel/forms.py
+++ b/adminpanel/forms.py
@@ -15,6 +15,8 @@ class ModifiedModelForm(ModelForm):
     @cached_property
     def changed_data(self):
         apparent_changed_data = super().changed_data
+        # Before validation, cleaned_data does not exist; defer to Django's raw
+        # bound-field change detection until cleaned values are available.
         if self._newly_created or not hasattr(self, "cleaned_data"):
             return apparent_changed_data
         model = self._meta.model

--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -92,8 +92,8 @@ def testSite(request):
 
 
 class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "admin_signin"
-    raise_exception = True
+    login_url = "adminLogin"
+    raise_exception = False
 
     def context_creater(self):
         recent_log = list(LogEntry.objects.order_by("-action_time")[:12])
@@ -191,7 +191,7 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
             more_than_ten_sessions=more_than_ten_sessions,
             category_with_most_qs=f"""\
                                 <a style="text-decoration: none;" \
-                                href="{reverse_lazy("adminDBObject", kwargs={'db':'category', 'pk':category_with_most_qs.pk})}" \
+                                href="{reverse_lazy("adminDBObject", kwargs={"db": "category", "pk": category_with_most_qs.pk})}" \
                                 title="{category_with_most_qs.name}">\
                                 This cat.</a>""",
             date_list=date_list,
@@ -221,7 +221,7 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
 
     def get_url_kwargs(self):
         db = str(self.kwargs["db"])
@@ -309,7 +309,7 @@ class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
     form_class = None
     initial = {}
 
@@ -407,7 +407,7 @@ class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
     form_class = None
     instance = None
 
@@ -474,14 +474,17 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
+        self.set_form_state(model, smallcaseDB, pk)
+        context = self.context_creator()
+        return render(request, "adminpanel/objectView.html", context)
+
+    def set_form_state(self, model, smallcaseDB, pk):
         setattr(AdminDBObjectCreate, "form_class", modelFormDict[smallcaseDB])
         setattr(
             AdminDBObjectChange,
             "instance",
             model.objects.get(pk=int(pk) if pk.isnumeric() else pk),
         )
-        context = self.context_creator()
-        return render(request, "adminpanel/objectView.html", context)
 
     def post(self, request, *args, **kwargs):
         smallcaseDB, pk = self.get_url_kwargs()
@@ -493,6 +496,7 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
+        self.set_form_state(model, smallcaseDB, pk)
 
         if request.POST.get("cancel"):
             return redirect("adminListDB", db=smallcaseDB)
@@ -512,7 +516,7 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
             pretty_msg = pretty_change_message(saved_object)
             messages.success(request, pretty_msg)
         if request.POST.get("save"):
-            return redirect("adminDBList", db=smallcaseDB)
+            return redirect("adminListDB", db=smallcaseDB)
         elif request.POST.get("save_continue"):
             return redirect("adminDBObject", db=smallcaseDB, pk=pk)
 
@@ -524,7 +528,7 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
     form_class = None
     instance = None
 
@@ -672,7 +676,7 @@ class AdminDBObjectHistory(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class ShowLogDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
 
     def context_creator(self):
         paginator = Paginator(LogEntry.objects.order_by("-action_time"), PAGINATE_NO)
@@ -704,7 +708,7 @@ class ShowLogDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class APIAccess(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
 
     def context_creator(self, request):
         token, created = Token.objects.get_or_create(user=request.user)
@@ -729,7 +733,7 @@ class APIAccess(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class APIDocs(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
 
     def context_creator(self, request):
         context = dict()
@@ -751,12 +755,12 @@ class APIDocs(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
 class GetQuestion(SuperuserRequiredMixin, LoginRequiredMixin, View):
     login_url = "adminLogin"
-    raise_exception = True
+    raise_exception = False
 
     def get(self, request, *args, **kwargs):
         response = {}
         count = self.request.GET.get("count")
-        count = int(count) if count.isdigit() else 1
+        count = int(count) if count and count.isdigit() else 1
         if count > 5:
             response["error"] = "Cannot request more than 5 objects."
             return JsonResponse(response, safe=False, encoder=QuestionEncoder)

--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -323,7 +323,7 @@ class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
     def get_form_class(self):
         """Return the form class to use."""
-        return AdminDBObjectCreate.form_class
+        return self.form_class
 
     def get_form(self, form_class=None):
         """Return an instance of the form to be used in this view."""
@@ -378,8 +378,7 @@ class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
             "lifeline",
         ):
             return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
-        model = modelDict[smallcaseDB]
-        setattr(AdminDBObjectCreate, "form_class", modelFormDict[smallcaseDB])
+        self.form_class = modelFormDict[smallcaseDB]
         context = self.context_creator()
         return render(request, "adminpanel/objectCreate.html", context)
 
@@ -392,6 +391,7 @@ class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
             return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
         if request.POST.get("cancel"):
             return redirect("adminListDB", db=smallcaseDB)
+        self.form_class = modelFormDict[smallcaseDB]
         form = self.get_form()
         if not form.is_valid():
             context = self.context_creator()
@@ -417,11 +417,11 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
 
     def get_instance(self):
         """Return the initial data to use for forms on this view."""
-        return AdminDBObjectChange.instance
+        return self.instance
 
     def get_form_class(self):
         """Return the form class to use."""
-        return AdminDBObjectCreate.form_class
+        return self.form_class
 
     def get_form(self, form_class=None):
         """Return an instance of the form to be used in this view."""
@@ -479,12 +479,8 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/objectView.html", context)
 
     def set_form_state(self, model, smallcaseDB, pk):
-        setattr(AdminDBObjectCreate, "form_class", modelFormDict[smallcaseDB])
-        setattr(
-            AdminDBObjectChange,
-            "instance",
-            model.objects.get(pk=int(pk) if pk.isnumeric() else pk),
-        )
+        self.form_class = modelFormDict[smallcaseDB]
+        self.instance = model.objects.get(pk=int(pk) if pk.isnumeric() else pk)
 
     def post(self, request, *args, **kwargs):
         smallcaseDB, pk = self.get_url_kwargs()

--- a/adminpanel/viewsExtra.py
+++ b/adminpanel/viewsExtra.py
@@ -102,6 +102,8 @@ def log_deletion(request, obj, object_repr):
     """
     from django.contrib.admin.models import DELETION, LogEntry
 
+    # Django's log_actions() derives object_repr from str(obj). Deletion logs
+    # keep accepting an explicit repr so callers can capture it before delete.
     log_entry = LogEntry(
         user_id=request.user.pk,
         content_type_id=get_content_type_for_model(obj).pk,

--- a/adminpanel/viewsExtra.py
+++ b/adminpanel/viewsExtra.py
@@ -69,13 +69,12 @@ def log_addition(request, obj, message):
     """
     from django.contrib.admin.models import ADDITION, LogEntry
 
-    return LogEntry.objects.log_action(
+    return LogEntry.objects.log_actions(
         user_id=request.user.pk,
-        content_type_id=get_content_type_for_model(obj).pk,
-        object_id=obj.pk,
-        object_repr=str(obj),
+        queryset=[obj],
         action_flag=ADDITION,
         change_message=message,
+        single_object=True,
     )
 
 
@@ -86,13 +85,12 @@ def log_change(request, obj, message):
     """
     from django.contrib.admin.models import CHANGE, LogEntry
 
-    return LogEntry.objects.log_action(
+    return LogEntry.objects.log_actions(
         user_id=request.user.pk,
-        content_type_id=get_content_type_for_model(obj).pk,
-        object_id=obj.pk,
-        object_repr=str(obj),
+        queryset=[obj],
         action_flag=CHANGE,
         change_message=message,
+        single_object=True,
     )
 
 
@@ -104,13 +102,15 @@ def log_deletion(request, obj, object_repr):
     """
     from django.contrib.admin.models import DELETION, LogEntry
 
-    return LogEntry.objects.log_action(
+    log_entry = LogEntry(
         user_id=request.user.pk,
         content_type_id=get_content_type_for_model(obj).pk,
         object_id=obj.pk,
         object_repr=object_repr,
         action_flag=DELETION,
     )
+    log_entry.save()
+    return log_entry
 
 
 def pretty_change_message(obj):

--- a/auth/views.py
+++ b/auth/views.py
@@ -82,7 +82,7 @@ def logout(request):
 def adminlogin(request):
     if request.user.is_authenticated:
         if request.user.is_superuser:
-            redirect("admin_page")
+            return redirect("adminMainPage")
         else:
             return redirect("mainpage")
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,9 @@
 import pytest
 
-@pytest.fixture(scope="session")
-def django_db_setup(django_test_environment, django_db_blocker):
-    with django_db_blocker.unblock():
-        pass  # Dev settings already use SQLite
 
 @pytest.fixture
 def api_client():
     """Return a DRF API client."""
     from rest_framework.test import APIClient
+
     return APIClient()

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -1,0 +1,191 @@
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+
+from game.models import Category, Option, Question
+
+
+@pytest.fixture
+def api_user():
+    return User.objects.create_user(username="apiuser", password="apiPass123")
+
+
+@pytest.fixture
+def auth_header(api_user):
+    token = Token.objects.create(user=api_user)
+    return {"HTTP_AUTHORIZATION": f"Token {token.key}"}
+
+
+@pytest.fixture
+def payload():
+    return {
+        "category": "Science",
+        "difficulty": "Easy",
+        "question": "What planet is known as the Red Planet?",
+        "correct_answer": "Mars",
+        "incorrect_answers": ["Venus", "Jupiter", "Mercury"],
+    }
+
+
+@pytest.fixture(autouse=True)
+def default_category():
+    Category.objects.get_or_create(name="None")
+
+
+def _post(client, data, headers):
+    return client.post(
+        reverse("addQuestionAPI"),
+        data=data,
+        content_type="application/json",
+        **headers,
+    )
+
+
+def _error_codes(response):
+    errors = response.json()["errors"]
+    if isinstance(errors, dict):
+        return {errors["status_code"]}
+    return {error["status_code"] for error in errors}
+
+
+@pytest.mark.django_db
+class TestAddQuestionAPI:
+    def test_valid_single_question_creates_question_and_relationships(
+        self, client, auth_header, api_user, payload
+    ):
+        science = Category.objects.create(name="Science")
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 201
+        assert response.json()["success"] == 1
+
+        question = Question.objects.get(text=payload["question"])
+        assert question.who_added == api_user
+        assert question.difficulty == Question.EASY
+        assert question.correct_option.text == "Mars"
+        assert list(question.falls_under.all()) == [science]
+        assert {option.text for option in question.incorrect_options.all()} == {
+            "Venus",
+            "Jupiter",
+            "Mercury",
+        }
+
+    def test_valid_multi_question_payload_creates_all_questions(
+        self, client, auth_header, payload
+    ):
+        questions = [
+            payload | {"question": f"Question {index}?", "correct_answer": f"A{index}"}
+            for index in range(3)
+        ]
+
+        response = _post(client, questions, auth_header)
+
+        assert response.status_code == 201
+        assert Question.objects.count() == 3
+
+    def test_non_list_payload_returns_400(self, client, auth_header, payload):
+        response = _post(client, payload, auth_header)
+
+        assert response.status_code == 400
+        assert response.json()["success"] == 0
+        assert response.json()["errors"]["status_code"] == 3
+
+    def test_empty_list_returns_400(self, client, auth_header):
+        response = _post(client, [], auth_header)
+
+        assert response.status_code == 400
+        assert response.json()["success"] == 0
+        assert response.json()["errors"]["status_code"] == 3
+
+    @pytest.mark.parametrize("missing_key", ["question", "difficulty"])
+    def test_missing_required_parameter_returns_status_4(
+        self, client, auth_header, payload, missing_key
+    ):
+        del payload[missing_key]
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {4}
+        assert Question.objects.count() == 0
+
+    def test_non_dict_question_returns_status_3(self, client, auth_header):
+        response = _post(client, ["not a dict"], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {3}
+
+    def test_incorrect_answers_must_have_three_values(
+        self, client, auth_header, payload
+    ):
+        payload["incorrect_answers"] = ["Only one"]
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {5}
+
+    def test_duplicate_question_text_returns_status_5(
+        self, client, auth_header, api_user, payload
+    ):
+        Question.objects.create(
+            who_added=api_user,
+            text=payload["question"],
+            difficulty=Question.EASY,
+            correct_option=Option.objects.create(text="Mars"),
+        )
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {5}
+
+    def test_invalid_difficulty_returns_status_5(self, client, auth_header, payload):
+        payload["difficulty"] = "Impossible"
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {5}
+
+    def test_invalid_option_returns_status_5(self, client, auth_header, payload):
+        payload["correct_answer"] = {"text": "Mars"}
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 409
+        assert _error_codes(response) == {5}
+
+    def test_unknown_category_uses_default_none_category(
+        self, client, auth_header, payload
+    ):
+        payload["category"] = "Unknown category"
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 201
+        question = Question.objects.get(text=payload["question"])
+        assert [category.name for category in question.falls_under.all()] == ["None"]
+
+    def test_category_list_deduplicates_and_falls_back_to_default(
+        self, client, auth_header, payload
+    ):
+        Category.objects.create(name="Science")
+        payload["category"] = ["Science", "Science", "Missing category"]
+
+        response = _post(client, [payload], auth_header)
+
+        assert response.status_code == 201
+        question = Question.objects.get(text=payload["question"])
+        assert {category.name for category in question.falls_under.all()} == {
+            "None",
+            "Science",
+        }
+
+    def test_missing_authorization_token_returns_401(self, client, payload):
+        response = _post(client, [payload], {})
+
+        assert response.status_code == 401
+        assert Question.objects.count() == 0

--- a/tests/unit/test_admin_views.py
+++ b/tests/unit/test_admin_views.py
@@ -19,7 +19,7 @@ def regular_user():
     return User.objects.create_user(username="player", password="playerPass123")
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def admin_data(superuser):
     category = Category.objects.create(name="General")
     none_category = Category.objects.get_or_create(name="None")[0]
@@ -53,9 +53,7 @@ def admin_client(client, superuser):
     return client
 
 
-def _admin_urls(admin_data):
-    category = admin_data["category"]
-    question = admin_data["question"]
+def _admin_urls(category_pk=1, question_pk=1):
     return [
         reverse("adminMainPage"),
         reverse("adminListDB", kwargs={"db": "session"}),
@@ -64,9 +62,9 @@ def _admin_urls(admin_data):
         reverse("adminListDB", kwargs={"db": "question"}),
         reverse("adminListDB", kwargs={"db": "option"}),
         reverse("adminDBObjectCreate", kwargs={"db": "category"}),
-        reverse("adminDBObject", kwargs={"db": "category", "pk": category.pk}),
-        reverse("adminDBObjectDelete", kwargs={"db": "category", "pk": category.pk}),
-        reverse("adminDBObjectHistory", kwargs={"db": "question", "pk": question.pk}),
+        reverse("adminDBObject", kwargs={"db": "category", "pk": category_pk}),
+        reverse("adminDBObjectDelete", kwargs={"db": "category", "pk": category_pk}),
+        reverse("adminDBObjectHistory", kwargs={"db": "question", "pk": question_pk}),
         reverse("adminListLogs"),
         reverse("APIAccess"),
         reverse("APIDocs"),
@@ -74,37 +72,49 @@ def _admin_urls(admin_data):
     ]
 
 
+def _admin_urls_for_data(admin_data):
+    return _admin_urls(
+        category_pk=admin_data["category"].pk,
+        question_pk=admin_data["question"].pk,
+    )
+
+
+ADMIN_URL_CASES = [
+    pytest.param(url, id=f"admin-url-{index}")
+    for index, url in enumerate(_admin_urls(), start=1)
+]
+
+
 @pytest.mark.django_db
 class TestAdminAccessControl:
-    @pytest.mark.parametrize("url_index", range(14))
-    def test_unauthenticated_requests_redirect_to_admin_login(
-        self, client, admin_data, url_index
-    ):
-        url = _admin_urls(admin_data)[url_index]
-
+    @pytest.mark.parametrize("url", ADMIN_URL_CASES)
+    def test_unauthenticated_requests_redirect_to_admin_login(self, client, url):
         response = client.get(url)
 
         assert response.status_code == 302
         assert response.url.startswith(reverse("adminLogin"))
 
-    @pytest.mark.parametrize("url_index", range(14))
-    def test_non_superuser_requests_return_403(
-        self, client, regular_user, admin_data, url_index
-    ):
+    @pytest.mark.parametrize("url", ADMIN_URL_CASES)
+    def test_non_superuser_requests_return_403(self, client, regular_user, url):
         client.force_login(regular_user)
-        url = _admin_urls(admin_data)[url_index]
 
         response = client.get(url)
 
         assert response.status_code == 403
 
-    @pytest.mark.parametrize("url_index", range(14))
+    @pytest.mark.parametrize(
+        "url_getter",
+        [
+            pytest.param(
+                lambda data, index=index: _admin_urls_for_data(data)[index], id=case.id
+            )
+            for index, case in enumerate(ADMIN_URL_CASES)
+        ],
+    )
     def test_superuser_requests_return_success_or_expected_redirect(
-        self, admin_client, admin_data, url_index
+        self, admin_client, admin_data, url_getter
     ):
-        url = _admin_urls(admin_data)[url_index]
-
-        response = admin_client.get(url)
+        response = admin_client.get(url_getter(admin_data))
 
         assert response.status_code in {200, 302}
 

--- a/tests/unit/test_admin_views.py
+++ b/tests/unit/test_admin_views.py
@@ -1,0 +1,208 @@
+import pytest
+from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
+from django.contrib.auth.models import User
+from django.urls import reverse
+from django.utils import timezone
+
+from game.models import Category, Lifeline, Option, Question, Session
+
+
+@pytest.fixture
+def superuser():
+    return User.objects.create_superuser(
+        username="admin", email="admin@example.com", password="adminPass123"
+    )
+
+
+@pytest.fixture
+def regular_user():
+    return User.objects.create_user(username="player", password="playerPass123")
+
+
+@pytest.fixture(autouse=True)
+def admin_data(superuser):
+    category = Category.objects.create(name="General")
+    none_category = Category.objects.get_or_create(name="None")[0]
+    correct = Option.objects.create(text="Correct")
+    wrong_options = [
+        Option.objects.create(text="Wrong 1"),
+        Option.objects.create(text="Wrong 2"),
+        Option.objects.create(text="Wrong 3"),
+    ]
+    question = Question.objects.create(
+        who_added=superuser,
+        text="Existing question?",
+        difficulty=Question.EASY,
+        correct_option=correct,
+    )
+    question.falls_under.set([category, none_category])
+    question.incorrect_options.set(wrong_options)
+    Lifeline.objects.create(name="Ask an expert", description="Expert help")
+    Session.objects.create(session_id="TEST1234", session_user=superuser, score=100)
+    return {
+        "category": category,
+        "correct": correct,
+        "wrong_options": wrong_options,
+        "question": question,
+    }
+
+
+@pytest.fixture
+def admin_client(client, superuser):
+    client.force_login(superuser)
+    return client
+
+
+def _admin_urls(admin_data):
+    category = admin_data["category"]
+    question = admin_data["question"]
+    return [
+        reverse("adminMainPage"),
+        reverse("adminListDB", kwargs={"db": "session"}),
+        reverse("adminListDB", kwargs={"db": "lifeline"}),
+        reverse("adminListDB", kwargs={"db": "category"}),
+        reverse("adminListDB", kwargs={"db": "question"}),
+        reverse("adminListDB", kwargs={"db": "option"}),
+        reverse("adminDBObjectCreate", kwargs={"db": "category"}),
+        reverse("adminDBObject", kwargs={"db": "category", "pk": category.pk}),
+        reverse("adminDBObjectDelete", kwargs={"db": "category", "pk": category.pk}),
+        reverse("adminDBObjectHistory", kwargs={"db": "question", "pk": question.pk}),
+        reverse("adminListLogs"),
+        reverse("APIAccess"),
+        reverse("APIDocs"),
+        reverse("getQuestionAPI") + "?count=1",
+    ]
+
+
+@pytest.mark.django_db
+class TestAdminAccessControl:
+    @pytest.mark.parametrize("url_index", range(14))
+    def test_unauthenticated_requests_redirect_to_admin_login(
+        self, client, admin_data, url_index
+    ):
+        url = _admin_urls(admin_data)[url_index]
+
+        response = client.get(url)
+
+        assert response.status_code == 302
+        assert response.url.startswith(reverse("adminLogin"))
+
+    @pytest.mark.parametrize("url_index", range(14))
+    def test_non_superuser_requests_return_403(
+        self, client, regular_user, admin_data, url_index
+    ):
+        client.force_login(regular_user)
+        url = _admin_urls(admin_data)[url_index]
+
+        response = client.get(url)
+
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize("url_index", range(14))
+    def test_superuser_requests_return_success_or_expected_redirect(
+        self, admin_client, admin_data, url_index
+    ):
+        url = _admin_urls(admin_data)[url_index]
+
+        response = admin_client.get(url)
+
+        assert response.status_code in {200, 302}
+
+
+@pytest.mark.django_db
+class TestAdminCRUDViews:
+    @pytest.mark.parametrize(
+        "model_name",
+        ["session", "lifeline", "category", "question", "option"],
+    )
+    def test_admin_list_db_shows_records(self, admin_client, admin_data, model_name):
+        expected_text_by_model = {
+            "session": str(Session.objects.get(score=100)),
+            "lifeline": "Ask an expert",
+            "category": "General",
+            "question": "Existing question?",
+            "option": "Correct",
+        }
+
+        response = admin_client.get(reverse("adminListDB", kwargs={"db": model_name}))
+
+        assert response.status_code == 200
+        assert expected_text_by_model[model_name] in response.content.decode()
+
+    def test_create_category_adds_object_and_log_entry(self, admin_client, superuser):
+        response = admin_client.post(
+            reverse("adminDBObjectCreate", kwargs={"db": "category"}),
+            {
+                "name": "History",
+                "date_created": timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
+                "create": "Create",
+            },
+        )
+
+        category = Category.objects.get(name="History")
+        assert response.status_code == 302
+        assert response.url == reverse(
+            "adminDBObject", kwargs={"db": "category", "pk": category.pk}
+        )
+        log = LogEntry.objects.get(object_id=str(category.pk), action_flag=ADDITION)
+        assert log.user == superuser
+        assert log.object_repr == str(category)
+
+    def test_change_category_updates_object_and_log_entry(
+        self, admin_client, admin_data, superuser
+    ):
+        category = admin_data["category"]
+
+        response = admin_client.post(
+            reverse("adminDBObject", kwargs={"db": "category", "pk": category.pk}),
+            {
+                "name": "Updated General",
+                "date_created": category.date_created.strftime("%Y-%m-%d %H:%M:%S"),
+                "save_continue": "Save and continue",
+            },
+        )
+
+        category.refresh_from_db()
+        assert response.status_code == 302
+        assert response.url == reverse(
+            "adminDBObject", kwargs={"db": "category", "pk": category.pk}
+        )
+        assert category.name == "Updated General"
+        log = LogEntry.objects.get(object_id=str(category.pk), action_flag=CHANGE)
+        assert log.user == superuser
+
+    def test_delete_category_yes_deletes_object_and_adds_log_entry(
+        self, admin_client, superuser
+    ):
+        category = Category.objects.create(name="Temporary")
+
+        response = admin_client.post(
+            reverse(
+                "adminDBObjectDelete", kwargs={"db": "category", "pk": category.pk}
+            ),
+            {"yes": "Yes"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("adminListDB", kwargs={"db": "category"})
+        assert not Category.objects.filter(pk=category.pk).exists()
+        log = LogEntry.objects.get(object_id=str(category.pk), action_flag=DELETION)
+        assert log.user == superuser
+        assert log.object_repr == "Temporary"
+
+    def test_delete_category_no_keeps_object_and_redirects_to_list(self, admin_client):
+        category = Category.objects.create(name="Keep me")
+
+        response = admin_client.post(
+            reverse(
+                "adminDBObjectDelete", kwargs={"db": "category", "pk": category.pk}
+            ),
+            {"no": "No"},
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse("adminListDB", kwargs={"db": "category"})
+        assert Category.objects.filter(pk=category.pk).exists()
+        assert not LogEntry.objects.filter(
+            object_id=str(category.pk), action_flag=DELETION
+        ).exists()


### PR DESCRIPTION
## Summary
- Add AddQuestion API coverage for valid payloads, validation failures, category fallback, duplicate questions, and token auth
- Add custom admin view access-control coverage plus list/create/change/delete tests with admin log verification
- Fix admin access redirects, admin CRUD persistence/logging, isolated pytest DB setup, and the admin-login superuser redirect exposed by the suite

## Verification
- DJANGO_SECRET_KEY=test-secret uv run pytest (105 passed, 36 existing timezone warnings)
- uv run ruff check conftest.py tests/unit/test_admin_api.py tests/unit/test_admin_views.py

Closes TRI-43
Closes TRI-64
Closes TRI-65
Closes TRI-66