### PR TITLE
Cover efficient question selection

### DIFF
--- a/game/models.py
+++ b/game/models.py
@@ -156,7 +156,10 @@ class Question(models.Model):
             text="None",
             correct_option_id=default_option_pk,
         )
-        if created or not question.incorrect_options.filter(pk=default_option_pk).exists():
+        if (
+            created
+            or not question.incorrect_options.filter(pk=default_option_pk).exists()
+        ):
             question.incorrect_options.add(default_option_pk)
         return question.pk
 
@@ -226,19 +229,23 @@ class Session(models.Model):
 
     @classmethod
     def get_next_question(cls, session_id):
-        sessionObj = cls.objects.get(session_id=session_id)
-        level_number = sessionObj.current_level.level_number
-        mode = "None"
-        if level_number >= 11:
-            mode = Question.HARD
-        elif level_number >= 6:
-            mode = Question.MEDIUM
-        else:
-            mode = Question.EASY
-        asked_pks = sessionObj.session_user.questions_asked.values_list("pk", flat=True)
+        session_level = cls.objects.filter(session_id=session_id).values(
+            "current_level__level_number"
+        )[:1]
         available_questions = (
-            Question.objects.filter(difficulty=mode)
-            .exclude(pk__in=asked_pks)
+            Question.objects.annotate(
+                session_level=models.Subquery(session_level),
+            )
+            .filter(
+                models.Q(session_level__gte=11, difficulty=Question.HARD)
+                | models.Q(
+                    session_level__gte=6,
+                    session_level__lte=10,
+                    difficulty=Question.MEDIUM,
+                )
+                | models.Q(session_level__lte=5, difficulty=Question.EASY)
+            )
+            .exclude(asked_to__initiated_sessions__session_id=session_id)
             .order_by("pk")
         )
         question_count = available_questions.count()

--- a/tests/unit/test_game_models.py
+++ b/tests/unit/test_game_models.py
@@ -83,3 +83,70 @@ class TestSetQuestion:
         assert list(session.questions_asked.all()) == [next_question]
         assert list(player.questions_asked.all()) == [next_question]
         get_next_question.assert_called_once_with(session.session_id)
+
+
+@pytest.mark.django_db
+class TestGetNextQuestion:
+    @pytest.mark.parametrize(
+        ("level_number", "expected_difficulty"),
+        [
+            (1, Question.EASY),
+            (5, Question.EASY),
+            (6, Question.MEDIUM),
+            (10, Question.MEDIUM),
+            (11, Question.HARD),
+            (15, Question.HARD),
+        ],
+    )
+    def test_selects_question_for_level_difficulty(
+        self, player, level_number, expected_difficulty
+    ):
+        level = Level.objects.create(level_number=level_number, money=100)
+        expected_question = create_question(
+            text=f"Question for level {level_number}",
+            difficulty=expected_difficulty,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) == expected_question
+
+    def test_excludes_questions_already_asked_to_player(self, player):
+        level = Level.objects.create(level_number=1, money=100)
+        asked_question = create_question(
+            text="Already asked",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        available_question = create_question(
+            text="Still available",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        asked_question.asked_to.add(player)
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) == available_question
+
+    def test_returns_none_when_difficulty_has_no_available_questions(self, player):
+        level = Level.objects.create(level_number=11, money=100)
+        create_question(
+            text="Easy only",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) is None
+
+    def test_stays_within_two_query_budget(self, player, django_assert_max_num_queries):
+        level = Level.objects.create(level_number=6, money=100)
+        create_question(
+            text="Medium question",
+            difficulty=Question.MEDIUM,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        with django_assert_max_num_queries(2):
+            Session.get_next_question(session.session_id)


### PR DESCRIPTION
Fixes TRI-55

### Description

Adds boundary coverage for Easy, Medium, and Hard question selection, excludes questions previously shown to the player, verifies empty pools return `None`, and enforces the two-query budget. The implementation now uses a session-level subquery so random offset selection remains efficient.

Stacked on: https://github.com/steadyfall/wwbm-webapp/pull/31

### Tests

- `source .env && uv run pytest tests/unit/test_game_models.py tests/unit/test_session_questions.py -q`
