### PR TITLE
Cover rules view branches

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -99,13 +99,8 @@ class Rules(LoginRequiredMixin, UserPassesTestMixin, View):
         return self.kwargs["session"]
 
     def test_func(self):
-        sessionId = self.get_sessionId()
-        check = Session.objects.filter(session_id=sessionId).exists()
-        if check:
-            sessionObj = Session.objects.get(session_id=sessionId)
-            if self.request.user == sessionObj.session_user:
-                return True
-        return False
+        sessionObj = Session.objects.filter(session_id=self.get_sessionId()).first()
+        return sessionObj is None or self.request.user == sessionObj.session_user
 
     def get(self, request, *args, **kwargs):
         sessionId = self.get_sessionId()

--- a/tests/unit/test_game_views.py
+++ b/tests/unit/test_game_views.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
@@ -189,3 +191,76 @@ class TestQuestionInGameAnswers:
         assert session.current_level == original_level
         assert session.gameOver is False
         assert not Option.hits.through.objects.filter(user=player).exists()
+
+
+@pytest.mark.django_db
+class TestRules:
+    def test_get_renders_rules_for_session_that_has_not_agreed(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        client.force_login(player)
+
+        response = client.get(reverse("rules", kwargs={"session": session.session_id}))
+
+        assert response.status_code == 200
+        assert "rules.html" in [template.name for template in response.templates]
+
+    def test_get_redirects_when_rules_are_already_agreed(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        client.force_login(player)
+
+        response = client.get(reverse("rules", kwargs={"session": session.session_id}))
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")
+
+    def test_post_agreement_updates_session_and_starts_first_question(
+        self, client, player, levels, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        client.force_login(player)
+
+        response = client.post(
+            reverse("rules", kwargs={"session": session.session_id}),
+            {"agreed": "yes"},
+        )
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == question_url(session, 1)
+        assert session.agreedToRules is True
+        assert session.prev_level == levels[-1]
+        assert session.current_level == levels[1]
+
+    def test_post_without_agreement_deletes_session(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        session_id = session.session_id
+        client.force_login(player)
+
+        response = client.post(reverse("rules", kwargs={"session": session_id}), {})
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")
+        assert not Session.objects.filter(session_id=session_id).exists()
+
+    def test_post_for_nonexistent_session_redirects_to_mainpage(self, client, player):
+        client.force_login(player)
+
+        response = client.post(
+            reverse("rules", kwargs={"session": uuid.uuid4()}),
+            {"agreed": "yes"},
+        )
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")


### PR DESCRIPTION
Fixes TRI-57

### Description

Adds coverage for rules rendering, prior agreement, accepted rules, missing agreement cleanup, and nonexistent sessions. Authenticated requests for missing sessions now reach the view's safe redirect path while ownership checks remain enforced for existing sessions.

Stacked on: https://github.com/steadyfall/wwbm-webapp/pull/33

### Tests

- `source .env && uv run pytest tests/unit/test_game_views.py tests/unit/test_game_session_flow.py -q`
