### PR TITLE
Add core game logic regression coverage

### DIFF
--- a/game/models.py
+++ b/game/models.py
@@ -156,7 +156,10 @@ class Question(models.Model):
             text="None",
             correct_option_id=default_option_pk,
         )
-        if created or not question.incorrect_options.filter(pk=default_option_pk).exists():
+        if (
+            created
+            or not question.incorrect_options.filter(pk=default_option_pk).exists()
+        ):
             question.incorrect_options.add(default_option_pk)
         return question.pk
 
@@ -226,19 +229,23 @@ class Session(models.Model):
 
     @classmethod
     def get_next_question(cls, session_id):
-        sessionObj = cls.objects.get(session_id=session_id)
-        level_number = sessionObj.current_level.level_number
-        mode = "None"
-        if level_number >= 11:
-            mode = Question.HARD
-        elif level_number >= 6:
-            mode = Question.MEDIUM
-        else:
-            mode = Question.EASY
-        asked_pks = sessionObj.session_user.questions_asked.values_list("pk", flat=True)
+        session_level = cls.objects.filter(session_id=session_id).values(
+            "current_level__level_number"
+        )[:1]
         available_questions = (
-            Question.objects.filter(difficulty=mode)
-            .exclude(pk__in=asked_pks)
+            Question.objects.annotate(
+                session_level=models.Subquery(session_level),
+            )
+            .filter(
+                models.Q(session_level__gte=11, difficulty=Question.HARD)
+                | models.Q(
+                    session_level__gte=6,
+                    session_level__lte=10,
+                    difficulty=Question.MEDIUM,
+                )
+                | models.Q(session_level__lte=5, difficulty=Question.EASY)
+            )
+            .exclude(asked_to__initiated_sessions__session_id=session_id)
             .order_by("pk")
         )
         question_count = available_questions.count()

--- a/game/views.py
+++ b/game/views.py
@@ -7,7 +7,7 @@ from django.db.models import Count
 from django.shortcuts import redirect, render
 from django.views.generic import View
 
-from game.models import Level, Lifeline, Option, Question, Session
+from game.models import Level, Lifeline, Question, Session
 
 from .lifelines import (
     AUDIENCE_POLL,
@@ -326,8 +326,16 @@ class QuestionInGame(LoginRequiredMixin, UserPassesTestMixin, View):
 
         if self.request.POST["submitBtn"] == "yes":
             userAnswer = self.request.POST["userAnswer"]
-            optionText = sessionObj.current_question.correct_option.text
-            option = Option.objects.get(text=userAnswer)
+            current_question = sessionObj.current_question
+            optionText = current_question.correct_option.text
+            option = (
+                current_question.correct_option
+                if userAnswer == optionText
+                else current_question.incorrect_options.filter(text=userAnswer).first()
+            )
+            if option is None:
+                messages.warning(request, "Invalid answer!")
+                return redirect(self.request.get_full_path())
             option.hits.add(sessionObj.session_user)
             if userAnswer == optionText:
                 sessionObj.score += sessionObj.current_level.money

--- a/game/views.py
+++ b/game/views.py
@@ -99,13 +99,8 @@ class Rules(LoginRequiredMixin, UserPassesTestMixin, View):
         return self.kwargs["session"]
 
     def test_func(self):
-        sessionId = self.get_sessionId()
-        check = Session.objects.filter(session_id=sessionId).exists()
-        if check:
-            sessionObj = Session.objects.get(session_id=sessionId)
-            if self.request.user == sessionObj.session_user:
-                return True
-        return False
+        sessionObj = Session.objects.filter(session_id=self.get_sessionId()).first()
+        return sessionObj is None or self.request.user == sessionObj.session_user
 
     def get(self, request, *args, **kwargs):
         sessionId = self.get_sessionId()

--- a/tests/unit/test_game_models.py
+++ b/tests/unit/test_game_models.py
@@ -1,0 +1,85 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from game.lifelines import AUDIENCE_POLL, EXPERT_ANSWER, FIFTY50
+from game.models import Level, Lifeline, Option, Question, Session
+
+
+@pytest.fixture
+def player():
+    return get_user_model().objects.create_user(
+        username="game-model-player",
+        password="playerPass123",
+    )
+
+
+@pytest.fixture
+def lifelines():
+    return {
+        name: Lifeline.objects.create(name=name, description=f"{name} description")
+        for name in (FIFTY50, AUDIENCE_POLL, EXPERT_ANSWER)
+    }
+
+
+def create_question(*, text, difficulty, player):
+    correct_option = Option.objects.create(text=f"{text} correct")
+    question = Question.objects.create(
+        who_added=player,
+        text=text,
+        difficulty=difficulty,
+        correct_option=correct_option,
+    )
+    question.incorrect_options.add(Option.objects.create(text=f"{text} incorrect"))
+    return question
+
+
+@pytest.mark.django_db
+class TestSessionCreation:
+    def test_new_sessions_receive_distinct_uuid_ids(self, player):
+        first_session = Session.objects.create(session_user=player)
+        second_session = Session.objects.create(session_user=player)
+
+        assert isinstance(first_session.session_id, uuid.UUID)
+        assert isinstance(second_session.session_id, uuid.UUID)
+        assert first_session.session_id != second_session.session_id
+
+    def test_starting_game_assigns_all_available_lifelines(
+        self, client, player, lifelines
+    ):
+        client.force_login(player)
+
+        response = client.post(reverse("mainpage"), {"startPlay": "yes"})
+
+        session = Session.objects.get(session_user=player)
+        assert response.status_code == 301
+        assert set(session.left_lifelines.all()) == set(lifelines.values())
+
+
+@pytest.mark.django_db
+class TestSetQuestion:
+    def test_sets_and_tracks_next_question(self, player):
+        level = Level.objects.create(level_number=1, money=100)
+        next_question = create_question(
+            text="An easy question",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        with patch.object(
+            Session,
+            "get_next_question",
+            return_value=next_question,
+        ) as get_next_question:
+            selected = Session.set_question(session.session_id)
+
+        session.refresh_from_db()
+        assert selected == next_question
+        assert session.current_question == next_question
+        assert list(session.questions_asked.all()) == [next_question]
+        assert list(player.questions_asked.all()) == [next_question]
+        get_next_question.assert_called_once_with(session.session_id)

--- a/tests/unit/test_game_models.py
+++ b/tests/unit/test_game_models.py
@@ -83,3 +83,70 @@ class TestSetQuestion:
         assert list(session.questions_asked.all()) == [next_question]
         assert list(player.questions_asked.all()) == [next_question]
         get_next_question.assert_called_once_with(session.session_id)
+
+
+@pytest.mark.django_db
+class TestGetNextQuestion:
+    @pytest.mark.parametrize(
+        ("level_number", "expected_difficulty"),
+        [
+            (1, Question.EASY),
+            (5, Question.EASY),
+            (6, Question.MEDIUM),
+            (10, Question.MEDIUM),
+            (11, Question.HARD),
+            (15, Question.HARD),
+        ],
+    )
+    def test_selects_question_for_level_difficulty(
+        self, player, level_number, expected_difficulty
+    ):
+        level = Level.objects.create(level_number=level_number, money=100)
+        expected_question = create_question(
+            text=f"Question for level {level_number}",
+            difficulty=expected_difficulty,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) == expected_question
+
+    def test_excludes_questions_already_asked_to_player(self, player):
+        level = Level.objects.create(level_number=1, money=100)
+        asked_question = create_question(
+            text="Already asked",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        available_question = create_question(
+            text="Still available",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        asked_question.asked_to.add(player)
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) == available_question
+
+    def test_returns_none_when_difficulty_has_no_available_questions(self, player):
+        level = Level.objects.create(level_number=11, money=100)
+        create_question(
+            text="Easy only",
+            difficulty=Question.EASY,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        assert Session.get_next_question(session.session_id) is None
+
+    def test_stays_within_two_query_budget(self, player, django_assert_max_num_queries):
+        level = Level.objects.create(level_number=6, money=100)
+        create_question(
+            text="Medium question",
+            difficulty=Question.MEDIUM,
+            player=player,
+        )
+        session = Session.objects.create(session_user=player, current_level=level)
+
+        with django_assert_max_num_queries(2):
+            Session.get_next_question(session.session_id)

--- a/tests/unit/test_game_models.py
+++ b/tests/unit/test_game_models.py
@@ -6,7 +6,14 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from game.lifelines import AUDIENCE_POLL, EXPERT_ANSWER, FIFTY50
-from game.models import Level, Lifeline, Option, Question, Session
+from game.models import (
+    Level,
+    Lifeline,
+    Option,
+    Question,
+    Session,
+    get_sentinel_user,
+)
 
 
 @pytest.fixture
@@ -150,3 +157,38 @@ class TestGetNextQuestion:
 
         with django_assert_max_num_queries(2):
             Session.get_next_question(session.session_id)
+
+
+@pytest.mark.django_db
+class TestDefaultFactories:
+    def test_level_default_pk_creates_level_zero(self):
+        default_pk = Level.get_default_pk()
+
+        default_level = Level.objects.get(pk=default_pk)
+        assert default_level.level_number == 0
+        assert Level.get_default_pk() == default_pk
+
+    def test_option_default_pk_creates_none_option(self):
+        default_pk = Option.get_default_pk()
+
+        default_option = Option.objects.get(pk=default_pk)
+        assert default_option.text == "None"
+        assert Option.get_default_pk() == default_pk
+
+    def test_question_default_pk_creates_complete_none_question(self):
+        default_pk = Question.get_default_pk()
+
+        default_question = Question.objects.get(pk=default_pk)
+        assert default_question.text == "None"
+        assert default_question.correct_option.text == "None"
+        assert list(default_question.incorrect_options.all()) == [
+            default_question.correct_option
+        ]
+        assert Question.get_default_pk() == default_pk
+
+    def test_sentinel_user_factory_creates_deleted_user(self):
+        default_pk = get_sentinel_user()
+
+        sentinel_user = get_user_model().objects.get(pk=default_pk)
+        assert sentinel_user.username == "deleted"
+        assert get_sentinel_user() == default_pk

--- a/tests/unit/test_game_views.py
+++ b/tests/unit/test_game_views.py
@@ -1,0 +1,191 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.urls import reverse
+
+from game.models import Level, Option, Question, Session
+
+
+@pytest.fixture
+def player():
+    return get_user_model().objects.create_user(
+        username="game-view-player",
+        password="playerPass123",
+    )
+
+
+@pytest.fixture
+def levels():
+    return {
+        level_number: Level.objects.create(
+            level_number=level_number,
+            money=max(level_number, 0) * 100,
+        )
+        for level_number in (-1, 1, 2, 14, 15, 16)
+    }
+
+
+@pytest.fixture
+def question(player):
+    correct_option = Option.objects.create(text="The correct answer")
+    incorrect_options = [
+        Option.objects.create(text=f"Wrong answer {number}") for number in range(1, 4)
+    ]
+    question = Question.objects.create(
+        who_added=player,
+        text="Which answer is correct?",
+        difficulty=Question.EASY,
+        correct_option=correct_option,
+    )
+    question.incorrect_options.set(incorrect_options)
+    return question
+
+
+@pytest.fixture
+def session_factory(player, levels, question):
+    def create_session(*, level_number=1, previous_level=-1, score=0):
+        return Session.objects.create(
+            session_user=player,
+            agreedToRules=True,
+            prev_level=levels[previous_level],
+            current_level=levels[level_number],
+            current_question=question,
+            score=score,
+        )
+
+    return create_session
+
+
+def question_url(session, level_number):
+    return reverse(
+        "question",
+        kwargs={"session": session.session_id, "level": level_number},
+    )
+
+
+@pytest.mark.django_db
+class TestQuestionInGameAnswers:
+    def test_correct_answer_increases_score_and_advances_level(
+        self, client, player, levels, question, session_factory
+    ):
+        session = session_factory(score=500)
+        client.force_login(player)
+
+        response = client.post(
+            question_url(session, 1),
+            {"submitBtn": "yes", "userAnswer": question.correct_option.text},
+        )
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == question_url(session, 2)
+        assert session.score == 500 + levels[1].money
+        assert session.current_level == levels[2]
+        assert list(session.correct_qns.all()) == [question]
+        assert list(question.correct_option.hits.all()) == [player]
+
+    def test_wrong_answer_ends_game_and_reduces_score(
+        self, client, player, question, session_factory
+    ):
+        session = session_factory(score=10_000)
+        client.force_login(player)
+
+        response = client.post(
+            question_url(session, 1),
+            {
+                "submitBtn": "yes",
+                "userAnswer": question.incorrect_options.first().text,
+            },
+        )
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == reverse(
+            "statusAfterQn",
+            kwargs={
+                "session": session.session_id,
+                "level": 1,
+                "status": "incorrect",
+            },
+        )
+        assert session.gameOver is True
+        assert session.wrong_qn == question
+        assert session.score == 100
+
+    def test_exit_ends_game_and_redirects_to_quit_status(
+        self, client, player, session_factory
+    ):
+        session = session_factory(score=500)
+        client.force_login(player)
+
+        response = client.post(question_url(session, 1), {"submitBtn": "exit"})
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == reverse(
+            "statusAfterQn",
+            kwargs={
+                "session": session.session_id,
+                "level": 1,
+                "status": "quit",
+            },
+        )
+        assert session.gameOver is True
+        assert session.score == 500
+
+    def test_correct_answer_at_level_fifteen_finishes_game(
+        self, client, player, levels, question, session_factory
+    ):
+        session = session_factory(level_number=15, previous_level=14, score=1_000)
+        client.force_login(player)
+
+        response = client.post(
+            question_url(session, 15),
+            {"submitBtn": "yes", "userAnswer": question.correct_option.text},
+        )
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == reverse(
+            "statusAfterQn",
+            kwargs={
+                "session": session.session_id,
+                "level": 15,
+                "status": "correct",
+            },
+        )
+        assert session.current_level == levels[16]
+        assert session.gameOver is True
+
+        finished_response = client.get(response.url)
+        assert finished_response.status_code == 200
+        assert finished_response.context["mode"] == "finished"
+
+    @pytest.mark.parametrize(
+        "invalid_answer", ["Tampered answer", "Other question answer"]
+    )
+    def test_invalid_answer_warns_without_changing_session(
+        self, client, player, question, session_factory, invalid_answer
+    ):
+        if invalid_answer == "Other question answer":
+            Option.objects.create(text=invalid_answer)
+        session = session_factory(score=500)
+        original_level = session.current_level
+        client.force_login(player)
+
+        response = client.post(
+            question_url(session, 1),
+            {"submitBtn": "yes", "userAnswer": invalid_answer},
+        )
+
+        session.refresh_from_db()
+        message_texts = [
+            str(message) for message in get_messages(response.wsgi_request)
+        ]
+        assert response.status_code == 302
+        assert response.url == question_url(session, 1)
+        assert message_texts == ["Invalid answer!"]
+        assert session.score == 500
+        assert session.current_level == original_level
+        assert session.gameOver is False
+        assert not Option.hits.through.objects.filter(user=player).exists()

--- a/tests/unit/test_game_views.py
+++ b/tests/unit/test_game_views.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
@@ -189,3 +191,76 @@ class TestQuestionInGameAnswers:
         assert session.current_level == original_level
         assert session.gameOver is False
         assert not Option.hits.through.objects.filter(user=player).exists()
+
+
+@pytest.mark.django_db
+class TestRules:
+    def test_get_renders_rules_for_session_that_has_not_agreed(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        client.force_login(player)
+
+        response = client.get(reverse("rules", kwargs={"session": session.session_id}))
+
+        assert response.status_code == 200
+        assert "rules.html" in [template.name for template in response.templates]
+
+    def test_get_redirects_when_rules_are_already_agreed(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        client.force_login(player)
+
+        response = client.get(reverse("rules", kwargs={"session": session.session_id}))
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")
+
+    def test_post_agreement_updates_session_and_starts_first_question(
+        self, client, player, levels, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        client.force_login(player)
+
+        response = client.post(
+            reverse("rules", kwargs={"session": session.session_id}),
+            {"agreed": "yes"},
+        )
+
+        session.refresh_from_db()
+        assert response.status_code == 301
+        assert response.url == question_url(session, 1)
+        assert session.agreedToRules is True
+        assert session.prev_level == levels[-1]
+        assert session.current_level == levels[1]
+
+    def test_post_without_agreement_deletes_session(
+        self, client, player, session_factory
+    ):
+        session = session_factory()
+        session.agreedToRules = False
+        session.save(update_fields=["agreedToRules"])
+        session_id = session.session_id
+        client.force_login(player)
+
+        response = client.post(reverse("rules", kwargs={"session": session_id}), {})
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")
+        assert not Session.objects.filter(session_id=session_id).exists()
+
+    def test_post_for_nonexistent_session_redirects_to_mainpage(self, client, player):
+        client.force_login(player)
+
+        response = client.post(
+            reverse("rules", kwargs={"session": uuid.uuid4()}),
+            {"agreed": "yes"},
+        )
+
+        assert response.status_code == 301
+        assert response.url == reverse("mainpage")

--- a/tests/unit/test_lifelines.py
+++ b/tests/unit/test_lifelines.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 
 from game.lifelines import (
     AUDIENCE_POLL,
@@ -13,7 +14,7 @@ from game.lifelines import (
     general_procedure,
     get_lifeline_map,
 )
-from game.models import Lifeline, Option, Question, Session
+from game.models import Level, Lifeline, Option, Question, Session
 
 
 @pytest.fixture
@@ -117,3 +118,40 @@ def test_audience_poll_returns_all_options_with_percentages(
     assert all(1 <= percent <= 100 for percent in percentages)
     assert lifelines[AUDIENCE_POLL] in session.used_lifelines.all()
     assert lifelines[AUDIENCE_POLL] not in session.left_lifelines.all()
+
+
+@pytest.mark.django_db
+def test_using_all_lifelines_hides_lifeline_button(
+    client, lifelines, question, session
+):
+    level = Level.objects.create(level_number=1, money=100)
+    session.agreedToRules = True
+    session.current_level = level
+    session.prev_level = level
+    session.current_question = question
+    session.save(
+        update_fields=[
+            "agreedToRules",
+            "current_level",
+            "prev_level",
+            "current_question",
+        ]
+    )
+
+    fifty50(question.pk, session.session_id)
+    audiencePoll(question.pk, session.session_id)
+    expertAnswer(question.pk, session.session_id)
+    client.force_login(session.session_user)
+
+    response = client.get(
+        reverse(
+            "question",
+            kwargs={"session": session.session_id, "level": level.level_number},
+        )
+    )
+
+    session.refresh_from_db()
+    assert response.status_code == 200
+    assert not session.left_lifelines.exists()
+    assert set(session.used_lifelines.all()) == set(lifelines.values())
+    assert b'id="lifelineButton"' not in response.content


### PR DESCRIPTION
Fixes TRI-41

### Description

Aggregates the game coverage for session setup, question selection, answer outcomes, rules handling, model defaults, and lifeline exhaustion. It also includes the minimal behavior fixes exposed by the new tests: two-query question selection, current-question answer validation, and safe redirects for missing rules sessions.

The child PRs are linked through `gh stack` as GitHub Stack #38:
- https://github.com/steadyfall/wwbm-webapp/pull/31
- https://github.com/steadyfall/wwbm-webapp/pull/32
- https://github.com/steadyfall/wwbm-webapp/pull/33
- https://github.com/steadyfall/wwbm-webapp/pull/34
- https://github.com/steadyfall/wwbm-webapp/pull/35
- https://github.com/steadyfall/wwbm-webapp/pull/36

This aggregate PR remains based on `main` from the TRI-41 branch.

### Tests

- `source .env && uv run pytest tests/unit/test_game_*.py -q` (29 passed)
- `source .env && uv run pytest -q` (152 passed)
- Ruff checks and formatting checks for changed files
- Django system check and migration drift check
