### PR TITLE
fix: pass category model object to dashboard context to prevent XSS

### DIFF
--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -233,13 +233,7 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
             percent_of_daily_threshold=percent_of_daily_threshold,
             percent_of_active_users=percent_of_active_users,
             more_than_ten_sessions=more_than_ten_sessions,
-            category_with_most_qs=""
-            if category_with_most_qs is None
-            else f"""\
-                                <a style="text-decoration: none;" \
-                                href="{reverse_lazy("adminDBObject", kwargs={"db": "category", "pk": category_with_most_qs.pk})}" \
-                                title="{category_with_most_qs.name}">\
-                                This cat.</a>""",
+            category_with_most_qs=category_with_most_qs,
             date_list=date_list,
             session_list=session_list,
             session_user_list=session_user_list,

--- a/templates/adminpanel/index.html
+++ b/templates/adminpanel/index.html
@@ -279,7 +279,14 @@
                                                 {{ total_category_count }} categories
                                             </div>
                                             <div class="text-muted">
-                                                {{ category_with_most_qs|safe }} has the most questions
+                                                {% if category_with_most_qs %}
+                                                <a style="text-decoration: none;"
+                                                    href="{% url 'adminDBObject' db='category' pk=category_with_most_qs.pk %}"
+                                                    title="{{ category_with_most_qs.name }}">This cat.</a>
+                                                {% else %}
+                                                No category
+                                                {% endif %}
+                                                has the most questions
                                             </div>
                                         </div>
                                     </div>

--- a/tests/unit/test_admin_views.py
+++ b/tests/unit/test_admin_views.py
@@ -139,6 +139,38 @@ class TestAdminDashboardPerformance:
 
 
 @pytest.mark.django_db
+class TestAdminDashboardContext:
+    def test_category_with_most_qs_is_category_instance(self, admin_data):
+        view = AdminMainPage()
+        view.request = RequestFactory().get(reverse("adminMainPage"))
+        view.kwargs = {}
+
+        context = view.context_creater()
+
+        assert isinstance(context["category_with_most_qs"], Category)
+
+    def test_dashboard_escapes_xss_payload_in_category_name(self, admin_client):
+        Category.objects.create(name="<script>alert(1)</script>")
+
+        response = admin_client.get(reverse("adminMainPage"))
+
+        html = response.content.decode()
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+    def test_dashboard_links_to_category_object_page(self, admin_client, admin_data):
+        category = admin_data["category"]
+
+        response = admin_client.get(reverse("adminMainPage"))
+
+        html = response.content.decode()
+        object_url = reverse(
+            "adminDBObject", kwargs={"db": "category", "pk": category.pk}
+        )
+        assert f'href="{object_url}"' in html
+
+
+@pytest.mark.django_db
 class TestAdminCRUDViews:
     @pytest.mark.parametrize(
         "model_name",


### PR DESCRIPTION
Fixes [TRI-37](https://linear.app/trivivo/issue/TRI-37/replace-raw-html-anchor-in-adminmainpage-context-with-model-xss)

### Description

`AdminMainPage` built a raw `<a>` tag with inline styling and an injectable `title` attribute in the view and passed it through the context as an HTML string (`{{ ...|safe }}`), bypassing Django's auto-escaping. A category name containing `"` or `>` could inject attributes into the rendered markup (stored XSS).

The context variable now carries the `Category` model instance, and the template renders the link with `{% url %}` and `{{ category_with_most_qs.name }}`, which is auto-escaped.

### Tests

- `test_category_with_most_qs_is_category_instance` — context contains a `Category` instance, not a string
- `test_dashboard_escapes_xss_payload_in_category_name` — `<script>alert(1)</script>` in a category name is HTML-escaped in the rendered page
- `test_dashboard_links_to_category_object_page` — link href points at the category object page
- Full suite: 141 passed; `make check` passes

Screenshots (also attached to the Linear ticket):

- [Admin dashboard after fix](https://uploads.linear.app/927408e4-ce1e-4049-8423-56eab0ed6b3d/ab466afc-9e6a-4fd9-824e-6b2fdae9fb0f/10f25033-54aa-4193-b13e-4aae2b0c7e75)
- [Categories card](https://uploads.linear.app/927408e4-ce1e-4049-8423-56eab0ed6b3d/813e1372-a90d-49f9-8bc7-e4bf51e8e622/5bc490e0-ec3f-4e44-8d19-0cc382b4ae3e)
