### PR TITLE
perf: sample random questions at DB level in get-question API

### DIFF
--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -41,7 +41,6 @@ from .viewsExtra import (
 )
 import datetime
 from operator import itemgetter
-import json, random
 
 
 modelDict: dict[str, models.Model] = {
@@ -800,8 +799,7 @@ class GetQuestion(SuperuserRequiredMixin, LoginRequiredMixin, View):
         if count > 5:
             response["error"] = "Cannot request more than 5 objects."
             return JsonResponse(response, safe=False, encoder=QuestionEncoder)
-        data = random.sample(list(Question.objects.all()), count)
-        response["data"] = data
+        response["data"] = list(Question.objects.order_by("?")[:count])
         return JsonResponse(response, safe=False, encoder=QuestionEncoder)
 
     def post(self, request, *args, **kwargs):

--- a/tests/unit/test_admin_api.py
+++ b/tests/unit/test_admin_api.py
@@ -189,3 +189,66 @@ class TestAddQuestionAPI:
 
         assert response.status_code == 401
         assert Question.objects.count() == 0
+
+
+@pytest.fixture
+def api_admin_user():
+    return User.objects.create_superuser(
+        username="apiadmin", email="apiadmin@example.com", password="adminPass123"
+    )
+
+
+@pytest.fixture
+def api_admin_client(client, api_admin_user):
+    client.force_login(api_admin_user)
+    return client
+
+
+@pytest.fixture
+def api_questions(api_admin_user):
+    questions = []
+    for index in range(3):
+        question = Question.objects.create(
+            who_added=api_admin_user,
+            text=f"Random question {index}?",
+            difficulty=Question.EASY,
+            correct_option=Option.objects.create(text=f"Answer {index}"),
+        )
+        question.incorrect_options.set(
+            [
+                Option.objects.create(text=f"Wrong {index} a"),
+                Option.objects.create(text=f"Wrong {index} b"),
+                Option.objects.create(text=f"Wrong {index} c"),
+            ]
+        )
+        questions.append(question)
+    return questions
+
+
+@pytest.mark.django_db
+class TestGetQuestionAPI:
+    def test_count_param_returns_that_many_questions(
+        self, api_admin_client, api_questions
+    ):
+        response = api_admin_client.get(reverse("getQuestionAPI") + "?count=3")
+
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 3
+
+    def test_missing_count_defaults_to_one(self, api_admin_client, api_questions):
+        response = api_admin_client.get(reverse("getQuestionAPI"))
+
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 1
+
+    def test_non_numeric_count_defaults_to_one(self, api_admin_client, api_questions):
+        response = api_admin_client.get(reverse("getQuestionAPI") + "?count=abc")
+
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 1
+
+    def test_count_above_limit_returns_error(self, api_admin_client, api_questions):
+        response = api_admin_client.get(reverse("getQuestionAPI") + "?count=10")
+
+        assert response.status_code == 200
+        assert response.json()["error"] == "Cannot request more than 5 objects."


### PR DESCRIPTION
Fixes [TRI-38](https://linear.app/trivivo/issue/TRI-38/replace-full-question-table-load-in-getquestion-api-with-db-level)

### Description

`GetQuestion` used `random.sample(list(Question.objects.all()), count)`, which deserialized the entire `Question` table into Python memory on every request (O(n) memory spike, discarding most rows). It now uses `Question.objects.order_by("?")[:count]` so the random sample happens in the database.

The `count` query parameter is also guarded: missing or non-numeric values default to `1`, and `count > 5` still returns the existing error response.

### Tests

- `test_count_param_returns_that_many_questions` — `?count=3` returns 3 questions
- `test_missing_count_defaults_to_one` — no param returns 1 question
- `test_non_numeric_count_defaults_to_one` — `?count=abc` returns 1 question
- `test_count_above_limit_returns_error` — `?count=10` returns the error response
- Full suite: 141 passed; `make check` passes
