### PR TITLE
refactor: extract shared CRUD helpers and base mixins in adminpanel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ misc
 .env.mcp
 *.egg-info
 .pytest_cache
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ run-tailwind: ## Start Tailwind CSS watcher only
 
 check: format lint ## Run all code quality checks (format, lint)
 	@printf "$(CYAN)>>> Running Django system checks...$(NC)\n"
-	$(MANAGE) check
+	source .env && $(MANAGE) check
 	@printf "$(GREEN)>>> All checks passed!$(NC)\n"
 
 test: ## Run pytest test suite with coverage reporting

--- a/adminpanel/admin.py
+++ b/adminpanel/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/adminpanel/crud.py
+++ b/adminpanel/crud.py
@@ -1,0 +1,44 @@
+"""Shared helpers for the admin panel's CRUD views."""
+
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+
+PAGINATE_NO = 12
+
+
+def paginate(queryset, page, per_page=PAGINATE_NO):
+    """Return the requested page, falling back to the first or last page."""
+    paginator = Paginator(queryset, per_page)
+    try:
+        return paginator.page(page)
+    except PageNotAnInteger:
+        return paginator.page(1)
+    except EmptyPage:
+        return paginator.page(paginator.num_pages)
+
+
+def build_breadcrumbs(items):
+    """Return items enumerated as (number, item) pairs for the templates."""
+    return [(number, item) for number, item in enumerate(items, start=1)]
+
+
+def record_context(model, kwargs, **extra):
+    """Return the shared context entries for a model-backed admin view."""
+    context = {
+        "recordVerboseName": model._meta.verbose_name,
+        "recordVerboseNamePlural": model._meta.verbose_name_plural,
+    }
+    context.update(kwargs)
+    context.update(extra)
+    return context
+
+
+def load_instance(model, pk):
+    """Load a model instance by primary key, coercing numeric string pks."""
+    return model.objects.get(pk=int(pk) if pk.isnumeric() else pk)
+
+
+def get_record(model, pk):
+    """Return the record for pk, falling back to the first record in the table."""
+    if model.objects.filter(pk=pk).exists():
+        return model.objects.get(pk=pk)
+    return model.objects.all()[0]

--- a/adminpanel/forms.py
+++ b/adminpanel/forms.py
@@ -1,8 +1,10 @@
-from django.forms import ModelForm, Form
-from django.utils.functional import cached_property
-from django.db.models import ManyToManyField
-from game.models import Question, Option, Lifeline, Category
 from copy import deepcopy
+
+from django.db.models import ManyToManyField
+from django.forms import ModelForm
+from django.utils.functional import cached_property
+
+from game.models import Category, Lifeline, Option, Question
 
 
 class ModifiedModelForm(ModelForm):
@@ -20,7 +22,7 @@ class ModifiedModelForm(ModelForm):
         if self._newly_created or not hasattr(self, "cleaned_data"):
             return apparent_changed_data
         model = self._meta.model
-        actual_changed_fields = list()
+        actual_changed_fields = []
         differenceBetweenFields = [
             (self.initial.get(x), self.cleaned_data[x]) for x in apparent_changed_data
         ]
@@ -46,13 +48,12 @@ class ModifiedModelForm(ModelForm):
             )
         model = self._meta.model
         if self._newly_created:
-            m2mFields = list(
-                filter(
-                    lambda x: isinstance(model._meta.get_field(x), ManyToManyField),
-                    self.cleaned_data.keys(),
-                )
-            )
-            m2mData = dict(list(map(lambda x: (x, self.cleaned_data[x]), m2mFields)))
+            m2mFields = [
+                x
+                for x in self.cleaned_data.keys()
+                if isinstance(model._meta.get_field(x), ManyToManyField)
+            ]
+            m2mData = {x: self.cleaned_data[x] for x in m2mFields}
             new_cleaned_data = deepcopy(self.cleaned_data)
             for field in m2mFields:
                 del new_cleaned_data[field]

--- a/adminpanel/models.py
+++ b/adminpanel/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/adminpanel/serializers.py
+++ b/adminpanel/serializers.py
@@ -1,17 +1,18 @@
 from django.core.serializers.json import DjangoJSONEncoder
-from game.models import Question, Option, Category
+
+from game.models import Question
 
 
 class QuestionEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Question):
             data = {}
-            data["categories"] = list(map(lambda cat: cat.name, obj.falls_under.all()))
+            data["categories"] = [cat.name for cat in obj.falls_under.all()]
             data["difficulty"] = obj.get_difficulty_display()
             data["question"] = obj.text
             data["correct_answer"] = obj.correct_option.text
-            data["incorrect_answers"] = list(
-                map(lambda option: option.text, obj.incorrect_options.all())
-            )
+            data["incorrect_answers"] = [
+                option.text for option in obj.incorrect_options.all()
+            ]
             return data
         return super().default(obj)

--- a/adminpanel/tests.py
+++ b/adminpanel/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/adminpanel/urls.py
+++ b/adminpanel/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
+
 from . import views as adminV
 
 urlpatterns = [

--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -1,47 +1,47 @@
-from django.shortcuts import render, HttpResponseRedirect, redirect
+import datetime
+
 from django.contrib import messages
-from django.urls import reverse, reverse_lazy
-from django.http import JsonResponse, HttpResponseNotAllowed
-
-from django.views.generic import View
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-
-from .forms import QuestionForm, OptionForm, LifelineForm, CategoryForm
-from django.forms import ModelForm
-from django.forms import modelform_factory
-
+from django.contrib.admin.models import LogEntry
+from django.contrib.admin.options import construct_change_message
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Count, F, Max, Q
 from django.db.models.functions import Length, Trim, TruncDate
-from django.contrib.auth.models import User
-from django.contrib.admin.models import LogEntry
-from game.models import Session, Lifeline, Category, Question, Option, QuestionOrder
-
-from rest_framework.authtoken.models import Token
+from django.forms import ModelForm
+from django.http import HttpResponseNotAllowed, HttpResponseRedirect, JsonResponse
+from django.shortcuts import redirect, render
+from django.urls import reverse_lazy
+from django.views.generic import View
 from rest_framework.authentication import TokenAuthentication
+from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
+from game.models import Category, Lifeline, Option, Question, QuestionOrder, Session
+
+from .crud import (
+    PAGINATE_NO,
+    build_breadcrumbs,
+    get_record,
+    load_instance,
+    paginate,
+    record_context,
+)
+from .forms import CategoryForm, LifelineForm, OptionForm, QuestionForm
 from .mixins import SuperuserRequiredMixin
-from django.contrib.auth.mixins import LoginRequiredMixin
-
-from django.contrib.admin.options import construct_change_message
 from .serializers import QuestionEncoder
-
 from .viewsExtra import (
-    pk_checker,
-    safe_pk_list_converter,
-    safe_object_delete_log,
-    pretty_change_message,
+    daterange,
+    get_content_type_for_model,
     log_addition,
     log_change,
     log_deletion,
-    daterange,
-    get_content_type_for_model,
+    pk_checker,
+    pretty_change_message,
+    safe_object_delete_log,
+    safe_pk_list_converter,
 )
-import datetime
-from operator import itemgetter
-
 
 modelDict: dict[str, models.Model] = {
     "session": Session,
@@ -58,21 +58,19 @@ modelFormDict: dict[str, ModelForm] = {
     "option": OptionForm,
 }
 allowedModelNames = tuple(modelDict.keys())
-addressOfPages = dict(
-    adminMainPage=reverse_lazy("adminMainPage"),
-    test=reverse_lazy("test"),
-    adminListDB=lambda x: reverse_lazy("adminListDB", kwargs=x),
-    adminListLogs=reverse_lazy("adminListLogs"),
-    adminDBObject=lambda x: reverse_lazy("adminDBObject", kwargs=x),
-    adminDBObjectCreate=lambda x: reverse_lazy("adminDBObjectCreate", kwargs=x),
-    adminDBObjectDelete=lambda x: reverse_lazy("adminDBObjectDelete", kwargs=x),
-    adminDBObjectHistory=lambda x: reverse_lazy("adminDBObjectHistory", kwargs=x),
-    APIAccess=reverse_lazy("APIAccess"),
-    APIDocs=reverse_lazy("APIDocs"),
-)
-after1stElement = itemgetter(slice(1, None))
+addressOfPages = {
+    "adminMainPage": reverse_lazy("adminMainPage"),
+    "test": reverse_lazy("test"),
+    "adminListDB": lambda x: reverse_lazy("adminListDB", kwargs=x),
+    "adminListLogs": reverse_lazy("adminListLogs"),
+    "adminDBObject": lambda x: reverse_lazy("adminDBObject", kwargs=x),
+    "adminDBObjectCreate": lambda x: reverse_lazy("adminDBObjectCreate", kwargs=x),
+    "adminDBObjectDelete": lambda x: reverse_lazy("adminDBObjectDelete", kwargs=x),
+    "adminDBObjectHistory": lambda x: reverse_lazy("adminDBObjectHistory", kwargs=x),
+    "APIAccess": reverse_lazy("APIAccess"),
+    "APIDocs": reverse_lazy("APIDocs"),
+}
 
-PAGINATE_NO = 12
 SITE_NAME = "AdminPanel"
 
 
@@ -90,10 +88,63 @@ def testSite(request):
 # Production sites
 
 
-class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
+class AdminViewBase(SuperuserRequiredMixin, LoginRequiredMixin, View):
+    """Base view for admin panel pages that require a superuser login."""
+
     login_url = "adminLogin"
     raise_exception = False
 
+    def redirect_back(self):
+        """Redirect back to the previous page or the admin panel root."""
+        return HttpResponseRedirect(self.request.META.get("HTTP_REFERER", "/admin/"))
+
+
+class FormStateMixin:
+    """Shared form-state handling for create and change views."""
+
+    form_class = None
+    initial = {}
+    instance = None
+
+    def get_initial(self):
+        """Return the initial data to use for forms on this view."""
+        return self.initial.copy()
+
+    def get_instance(self):
+        """Return the model instance bound to forms on this view."""
+        return self.instance
+
+    def get_form_class(self):
+        """Return the form class to use."""
+        return self.form_class
+
+    def get_form_kwargs(self):
+        """Return the keyword arguments for instantiating the form."""
+        kwargs = {"initial": self.get_initial()}
+
+        if self.request.method in ("POST", "PUT"):
+            kwargs.update(
+                {
+                    "data": self.request.POST,
+                    "files": self.request.FILES,
+                }
+            )
+        if self.get_instance() is not None:
+            kwargs["instance"] = self.get_instance()
+        return kwargs
+
+    def get_form(self, form_class=None):
+        """Return an instance of the form to be used in this view."""
+        if form_class is None:
+            form_class = self.get_form_class()
+        return form_class(**self.get_form_kwargs())
+
+    def set_form_class(self, db):
+        """Set the form class used by this view for the given model name."""
+        self.form_class = modelFormDict[db]
+
+
+class AdminMainPage(AdminViewBase):
     def add_object_exists_to_logs(self, logs):
         logs_by_model = {}
         for log in logs:
@@ -166,7 +217,7 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
             session_medium_list,
             session_hard_list,
             score_list,
-        ) = [list() for _ in range(7)]
+        ) = [[] for _ in range(7)]
         start_date = datetime.date.today() - datetime.timedelta(15)
         end_date = datetime.date.today() + datetime.timedelta(1)
         session_stats = {
@@ -217,39 +268,37 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
             user.session_count for user in users_with_session_counts
         ]
 
-        context = dict(
-            recent_log=recent_log,
-            total_question_count=total_question_count,
-            daily_question_count=daily_question_count,
-            total_session_count=total_session_count,
-            daily_session_count=daily_session_count,
-            top_30_highest_scores=top_30_highest_scores,
-            highest_score=highest_score,
-            total_user_count=total_user_count,
-            daily_user_count=daily_user_count,
-            total_category_count=f"{len(categories):,}",
-            active_users_count=active_users_count,
-            percent_of_daily_threshold=percent_of_daily_threshold,
-            percent_of_active_users=percent_of_active_users,
-            more_than_ten_sessions=more_than_ten_sessions,
-            category_with_most_qs=category_with_most_qs,
-            date_list=date_list,
-            session_list=session_list,
-            session_user_list=session_user_list,
-            session_easy_list=session_easy_list,
-            session_medium_list=session_medium_list,
-            session_hard_list=session_hard_list,
-            score_list=score_list,
-            active_users_labels=active_users_labels,
-            active_users_activity=active_users_activity,
-        )
+        context = {
+            "recent_log": recent_log,
+            "total_question_count": total_question_count,
+            "daily_question_count": daily_question_count,
+            "total_session_count": total_session_count,
+            "daily_session_count": daily_session_count,
+            "top_30_highest_scores": top_30_highest_scores,
+            "highest_score": highest_score,
+            "total_user_count": total_user_count,
+            "daily_user_count": daily_user_count,
+            "total_category_count": f"{len(categories):,}",
+            "active_users_count": active_users_count,
+            "percent_of_daily_threshold": percent_of_daily_threshold,
+            "percent_of_active_users": percent_of_active_users,
+            "more_than_ten_sessions": more_than_ten_sessions,
+            "category_with_most_qs": category_with_most_qs,
+            "date_list": date_list,
+            "session_list": session_list,
+            "session_user_list": session_user_list,
+            "session_easy_list": session_easy_list,
+            "session_medium_list": session_medium_list,
+            "session_hard_list": session_hard_list,
+            "score_list": score_list,
+            "active_users_labels": active_users_labels,
+            "active_users_activity": active_users_activity,
+        }
         breadcrumbs = [
             ["Admin", addressOfPages["adminMainPage"]],
             [[], []],
         ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
-        )
+        context["breadcrumbs"] = build_breadcrumbs(breadcrumbs)
         context.update(self.kwargs)
         return context
 
@@ -258,13 +307,9 @@ class AdminMainPage(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/index.html", context)
 
 
-class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class AdminListDB(AdminViewBase):
     def get_url_kwargs(self):
-        db = str(self.kwargs["db"])
-        return db
+        return str(self.kwargs["db"])
 
     def context_creator(self):
         smallcaseDB = self.get_url_kwargs()
@@ -274,36 +319,45 @@ class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
             .annotate(key_primary=F(model._meta.pk.name))
             .order_by("-key_primary")
         )
-        paginator = Paginator(query, PAGINATE_NO)
-        page = self.request.GET.get("page", 1)
-        try:
-            objects_list = paginator.page(page)
-        except PageNotAnInteger:
-            objects_list = paginator.page(1)
-        except EmptyPage:
-            objects_list = paginator.page(paginator.num_pages)
-        context = {
-            "allRecords": objects_list,
-            "recordVerboseName": model._meta.verbose_name,
-            "recordVerboseNamePlural": model._meta.verbose_name_plural,
-        }
-        context.update(self.kwargs)
+        objects_list = paginate(query, self.request.GET.get("page", 1), PAGINATE_NO)
+        context = record_context(model, self.kwargs, allRecords=objects_list)
         context["title"] = SITE_NAME + " - " + context["recordVerboseName"]
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            [smallcaseDB.title()],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+        context["breadcrumbs"] = build_breadcrumbs(
+            [
+                ["Admin", addressOfPages["adminMainPage"]],
+                [smallcaseDB.title()],
+            ]
         )
         return context
 
     def get(self, request, *args, **kwargs):
         smallcaseDB = self.get_url_kwargs()
         if smallcaseDB not in allowedModelNames:
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
         context = self.context_creator()
         return render(request, "adminpanel/listdb.html", context)
+
+    def is_bulk_delete_request(self, request, model, given_pk, safe_given_pk):
+        """Return True when the request deletes a fully validated selection."""
+        admin_action = request.POST.get("admin-action")
+        if (
+            admin_action not in ("Delete selected", "Delete all in view")
+            or not given_pk
+        ):
+            return False
+        valid_pks = set(
+            model.objects.all()
+            .annotate(key_primary=F(model._meta.pk.name))
+            .values_list("key_primary", flat=True)
+        )
+        if set(safe_given_pk) - valid_pks:
+            return False
+        if admin_action == "Delete selected":
+            return True
+        return (
+            bool(request.POST.get("allcheck"))
+            and len(set(safe_given_pk)) == PAGINATE_NO
+        )
 
     def post(self, request, *args, **kwargs):
         smallcaseDB = self.get_url_kwargs()
@@ -311,32 +365,21 @@ class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
             smallcaseDB not in allowedModelNames
             or request.POST.get("admin-action") == "-"
         ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
 
         model = modelDict[smallcaseDB]
-        query = model.objects.all().annotate(key_primary=F(model._meta.pk.name))
         given_pk = request.POST.getlist("indcheck")
         safe_given_pk = safe_pk_list_converter(given_pk, model)
-        if (
-            request.POST.get("admin-action") == "Delete selected"
-            and given_pk
-            and (set(safe_given_pk) - set(map(lambda y: y.key_primary, query)) == set())
-        ) or (
-            request.POST.get("admin-action") == "Delete all in view"
-            and request.POST.get("allcheck")
-            and given_pk
-            and (set(safe_given_pk) - set(map(lambda y: y.key_primary, query)) == set())
-            and len(set(safe_given_pk)) == PAGINATE_NO
-        ):
+        if self.is_bulk_delete_request(request, model, given_pk, safe_given_pk):
             object_name = (
                 model._meta.verbose_name
                 if len(given_pk) == 1
                 else model._meta.verbose_name_plural
             )
-            action = list(
-                map(lambda x: safe_object_delete_log(request, model, x), safe_given_pk)
-            )
-            deleted = sum(list(map(lambda x: x[0], action)))
+            action = [
+                safe_object_delete_log(request, model, pk) for pk in safe_given_pk
+            ]
+            deleted = sum(result[0] for result in action)
             messages.success(
                 request,
                 f"""Successfully deleted {len(action)} {object_name} and {deleted} objects related to it!""",
@@ -346,91 +389,53 @@ class AdminListDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/listdb.html", context)
 
 
-class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-    form_class = None
-    initial = {}
-
+class AdminDBObjectCreate(AdminViewBase, FormStateMixin):
     def get_url_kwargs(self):
-        db = str(self.kwargs["db"])
-        return db
+        return str(self.kwargs["db"])
 
-    def get_initial(self):
-        """Return the initial data to use for forms on this view."""
-        return self.initial.copy()
-
-    def get_form_class(self):
-        """Return the form class to use."""
-        return self.form_class
-
-    def get_form(self, form_class=None):
-        """Return an instance of the form to be used in this view."""
-        if form_class is None:
-            form_class = self.get_form_class()
-        return form_class(**self.get_form_kwargs())
-
-    def get_form_kwargs(self):
-        """Return the keyword arguments for instantiating the form."""
-        kwargs = {
-            "initial": self.get_initial(),
-        }
-
-        if self.request.method in ("POST", "PUT"):
-            kwargs.update(
-                {
-                    "data": self.request.POST,
-                    "files": self.request.FILES,
-                }
-            )
-        return kwargs
+    def is_creatable(self, smallcaseDB):
+        return smallcaseDB not in allowedModelNames or smallcaseDB in (
+            "session",
+            "lifeline",
+        )
 
     def context_creator(self):
         smallcaseDB = self.get_url_kwargs()
         model = modelDict[smallcaseDB]
-        context = {
-            "form": self.get_form(),
-            "recordVerboseName": model._meta.verbose_name,
-            "recordVerboseNamePlural": model._meta.verbose_name_plural,
-        }
-        context.update(self.kwargs)
+        context = record_context(model, self.kwargs, form=self.get_form())
         context["title"] = (
             SITE_NAME + " - Create " + context["recordVerboseName"].title()
         )
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            [smallcaseDB.title(), addressOfPages["adminListDB"]({"db": smallcaseDB})],
+        context["breadcrumbs"] = build_breadcrumbs(
             [
-                f"Create {smallcaseDB.title()}",
-                addressOfPages["adminDBObjectCreate"]({"db": smallcaseDB}),
-            ],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+                ["Admin", addressOfPages["adminMainPage"]],
+                [
+                    smallcaseDB.title(),
+                    addressOfPages["adminListDB"]({"db": smallcaseDB}),
+                ],
+                [
+                    f"Create {smallcaseDB.title()}",
+                    addressOfPages["adminDBObjectCreate"]({"db": smallcaseDB}),
+                ],
+            ]
         )
         return context
 
     def get(self, request, *args, **kwargs):
         smallcaseDB = self.get_url_kwargs()
-        if smallcaseDB not in allowedModelNames or smallcaseDB in (
-            "session",
-            "lifeline",
-        ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
-        self.form_class = modelFormDict[smallcaseDB]
+        if self.is_creatable(smallcaseDB):
+            return self.redirect_back()
+        self.set_form_class(smallcaseDB)
         context = self.context_creator()
         return render(request, "adminpanel/objectCreate.html", context)
 
     def post(self, request, *args, **kwargs):
         smallcaseDB = self.get_url_kwargs()
-        if smallcaseDB not in allowedModelNames or smallcaseDB in (
-            "session",
-            "lifeline",
-        ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+        if self.is_creatable(smallcaseDB):
+            return self.redirect_back()
         if request.POST.get("cancel"):
             return redirect("adminListDB", db=smallcaseDB)
-        self.form_class = modelFormDict[smallcaseDB]
+        self.set_form_class(smallcaseDB)
         form = self.get_form()
         if not form.is_valid():
             context = self.context_creator()
@@ -444,72 +449,39 @@ class AdminDBObjectCreate(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return redirect("adminListDB", db=smallcaseDB)
 
 
-class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-    form_class = None
-    instance = None
-
+class AdminDBObjectChange(AdminViewBase, FormStateMixin):
     def get_url_kwargs(self):
         db, pk = str(self.kwargs["db"]), str(self.kwargs["pk"])
         return (db, pk)
 
-    def get_instance(self):
-        """Return the initial data to use for forms on this view."""
-        return self.instance
-
-    def get_form_class(self):
-        """Return the form class to use."""
-        return self.form_class
-
-    def get_form(self, form_class=None):
-        """Return an instance of the form to be used in this view."""
-        if form_class is None:
-            form_class = self.get_form_class()
-        return form_class(**self.get_form_kwargs())
-
-    def get_form_kwargs(self):
-        """Return the keyword arguments for instantiating the form."""
-        kwargs = {
-            "instance": self.get_instance(),
-        }
-
-        if self.request.method in ("POST", "PUT"):
-            kwargs.update(
-                {
-                    "data": self.request.POST,
-                    "files": self.request.FILES,
-                }
-            )
-        return kwargs
-
     def context_creator(self):
         smallcaseDB, pk = self.get_url_kwargs()
         model = modelDict[smallcaseDB]
-        context = {
-            "form": self.get_form(),
-            "recordVerboseName": model._meta.verbose_name,
-            "recordVerboseNamePlural": model._meta.verbose_name_plural,
-        }
-        context.update(self.kwargs)
+        context = record_context(model, self.kwargs, form=self.get_form())
         context["title"] = SITE_NAME + " - View " + context["recordVerboseName"].title()
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            [smallcaseDB.title(), addressOfPages["adminListDB"]({"db": smallcaseDB})],
+        context["breadcrumbs"] = build_breadcrumbs(
             [
-                f"View {smallcaseDB.title()}",
-                addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
-            ],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+                ["Admin", addressOfPages["adminMainPage"]],
+                [
+                    smallcaseDB.title(),
+                    addressOfPages["adminListDB"]({"db": smallcaseDB}),
+                ],
+                [
+                    f"View {smallcaseDB.title()}",
+                    addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
+                ],
+            ]
         )
         return context
 
+    def set_form_state(self, model, smallcaseDB, pk):
+        self.set_form_class(smallcaseDB)
+        self.instance = load_instance(model, pk)
+
     def get(self, request, *args, **kwargs):
         smallcaseDB, pk = self.get_url_kwargs()
-        if smallcaseDB not in allowedModelNames or smallcaseDB in ("session"):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+        if smallcaseDB not in allowedModelNames or smallcaseDB == "session":
+            return self.redirect_back()
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
@@ -517,17 +489,13 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
         context = self.context_creator()
         return render(request, "adminpanel/objectView.html", context)
 
-    def set_form_state(self, model, smallcaseDB, pk):
-        self.form_class = modelFormDict[smallcaseDB]
-        self.instance = model.objects.get(pk=int(pk) if pk.isnumeric() else pk)
-
     def post(self, request, *args, **kwargs):
         smallcaseDB, pk = self.get_url_kwargs()
         if smallcaseDB not in allowedModelNames or smallcaseDB in (
             "session",
             "lifeline",
         ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
@@ -561,12 +529,7 @@ class AdminDBObjectChange(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return redirect("adminListDB", db=smallcaseDB)
 
 
-class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-    form_class = None
-    instance = None
-
+class AdminDBObjectDelete(AdminViewBase):
     def get_url_kwargs(self):
         db, pk = str(self.kwargs["db"]), str(self.kwargs["pk"])
         return (db, pk)
@@ -574,30 +537,29 @@ class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
     def context_creator(self):
         smallcaseDB, pk = self.get_url_kwargs()
         model = modelDict[smallcaseDB]
-        obj = model.objects.get(pk=pk)
-        context = {
-            "record": obj,
-            "recordVerboseName": model._meta.verbose_name,
-            "recordVerboseNamePlural": model._meta.verbose_name_plural,
-        }
-        context.update(self.kwargs)
+        obj = load_instance(model, pk)
+        context = record_context(model, self.kwargs, record=obj)
         context["title"] = (
             SITE_NAME + " - Confirm deleting " + context["recordVerboseName"] + "?"
         )
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            [smallcaseDB.title(), addressOfPages["adminListDB"]({"db": smallcaseDB})],
+        context["breadcrumbs"] = build_breadcrumbs(
             [
-                f"View {smallcaseDB.title()}",
-                addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
-            ],
-            [
-                f"Delete '{obj}'",
-                addressOfPages["adminDBObjectDelete"]({"db": smallcaseDB, "pk": pk}),
-            ],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+                ["Admin", addressOfPages["adminMainPage"]],
+                [
+                    smallcaseDB.title(),
+                    addressOfPages["adminListDB"]({"db": smallcaseDB}),
+                ],
+                [
+                    f"View {smallcaseDB.title()}",
+                    addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
+                ],
+                [
+                    f"Delete '{obj}'",
+                    addressOfPages["adminDBObjectDelete"](
+                        {"db": smallcaseDB, "pk": pk}
+                    ),
+                ],
+            ]
         )
         return context
 
@@ -607,7 +569,7 @@ class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
             "session",
             "lifeline",
         ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
@@ -620,7 +582,7 @@ class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
             "session",
             "lifeline",
         ):
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
@@ -638,10 +600,7 @@ class AdminDBObjectDelete(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return redirect("adminListDB", db=smallcaseDB)
 
 
-class AdminDBObjectHistory(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class AdminDBObjectHistory(AdminViewBase):
     def get_url_kwargs(self):
         db, pk = str(self.kwargs["db"]), str(self.kwargs["pk"])
         return (db, pk)
@@ -650,58 +609,53 @@ class AdminDBObjectHistory(SuperuserRequiredMixin, LoginRequiredMixin, View):
         smallcaseDB, pk = self.get_url_kwargs()
         model = modelDict[smallcaseDB]
 
-        obj = model.objects.all()[0]
-        if model.objects.filter(pk=pk).exists():
-            obj = model.objects.get(pk=pk)
+        obj = get_record(model, pk)
 
         query = LogEntry.objects.filter(
             content_type_id=get_content_type_for_model(obj).pk, object_id=pk
         ).order_by("-action_time")
 
-        if query.exists():
-            paginator = Paginator(query, PAGINATE_NO)
-            page = self.request.GET.get("page", 1)
-            try:
-                objects_list = paginator.page(page)
-            except PageNotAnInteger:
-                objects_list = paginator.page(1)
-            except EmptyPage:
-                objects_list = paginator.page(paginator.num_pages)
-        else:
-            objects_list = None
-
-        context = dict(
-            record=obj,
-            recordVerboseName=model._meta.verbose_name,
-            recordVerboseNamePlural=model._meta.verbose_name_plural,
-            query=objects_list,
-            object_name=query[0].object_repr if query.exists() else str(obj),
+        objects_list = (
+            paginate(query, self.request.GET.get("page", 1), PAGINATE_NO)
+            if query.exists()
+            else None
         )
-        context.update(self.kwargs)
+
+        context = record_context(
+            model,
+            self.kwargs,
+            record=obj,
+            query=objects_list,
+            object_name=objects_list[0].object_repr if objects_list else str(obj),
+        )
         context["title"] = (
             SITE_NAME + " - " + "History of " + f'"{context["object_name"]}"'
         )
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            [smallcaseDB.title(), addressOfPages["adminListDB"]({"db": smallcaseDB})],
+        context["breadcrumbs"] = build_breadcrumbs(
             [
-                f"View {smallcaseDB.title()}",
-                addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
-            ],
-            [
-                f"History of '{obj}'",
-                addressOfPages["adminDBObjectHistory"]({"db": smallcaseDB, "pk": pk}),
-            ],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+                ["Admin", addressOfPages["adminMainPage"]],
+                [
+                    smallcaseDB.title(),
+                    addressOfPages["adminListDB"]({"db": smallcaseDB}),
+                ],
+                [
+                    f"View {smallcaseDB.title()}",
+                    addressOfPages["adminDBObject"]({"db": smallcaseDB, "pk": pk}),
+                ],
+                [
+                    f"History of '{obj}'",
+                    addressOfPages["adminDBObjectHistory"](
+                        {"db": smallcaseDB, "pk": pk}
+                    ),
+                ],
+            ]
         )
         return context
 
     def get(self, request, *args, **kwargs):
         smallcaseDB, pk = self.get_url_kwargs()
         if smallcaseDB not in allowedModelNames:
-            return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+            return self.redirect_back()
         model = modelDict[smallcaseDB]
         if not pk_checker(pk, model):
             return redirect("adminListDB", db=smallcaseDB)
@@ -709,30 +663,21 @@ class AdminDBObjectHistory(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/objectHistory.html", context)
 
 
-class ShowLogDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class ShowLogDB(AdminViewBase):
     def context_creator(self):
-        paginator = Paginator(LogEntry.objects.order_by("-action_time"), PAGINATE_NO)
-        page = self.request.GET.get("page", 1)
-        try:
-            objects_list = paginator.page(page)
-        except PageNotAnInteger:
-            objects_list = paginator.page(1)
-        except EmptyPage:
-            objects_list = paginator.page(paginator.num_pages)
-        context = dict(
-            allRecords=objects_list,
+        objects_list = paginate(
+            LogEntry.objects.order_by("-action_time"),
+            self.request.GET.get("page", 1),
+            PAGINATE_NO,
         )
+        context = {"allRecords": objects_list}
         context.update(self.kwargs)
         context["title"] = SITE_NAME + " - " + "Changelog"
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            ["Logs", addressOfPages["adminListLogs"]],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+        context["breadcrumbs"] = build_breadcrumbs(
+            [
+                ["Admin", addressOfPages["adminMainPage"]],
+                ["Logs", addressOfPages["adminListLogs"]],
+            ]
         )
         return context
 
@@ -741,23 +686,19 @@ class ShowLogDB(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/listlog.html", context)
 
 
-class APIAccess(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class APIAccess(AdminViewBase):
     def context_creator(self, request):
         token, created = Token.objects.get_or_create(user=request.user)
-        context = dict()
+        context = {}
         context.update(self.kwargs)
         context["token"] = token.key
         context["created"] = token.created
         context["title"] = SITE_NAME + " - " + "API Token"
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            ["API Access", addressOfPages["APIAccess"]],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+        context["breadcrumbs"] = build_breadcrumbs(
+            [
+                ["Admin", addressOfPages["adminMainPage"]],
+                ["API Access", addressOfPages["APIAccess"]],
+            ]
         )
         return context
 
@@ -766,20 +707,16 @@ class APIAccess(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/apiaccess.html", context)
 
 
-class APIDocs(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class APIDocs(AdminViewBase):
     def context_creator(self, request):
-        context = dict()
+        context = {}
         context.update(self.kwargs)
         context["title"] = SITE_NAME + " - " + "API Docs"
-        breadcrumbs = [
-            ["Admin", addressOfPages["adminMainPage"]],
-            ["API Docs", addressOfPages["APIDocs"]],
-        ]
-        context["breadcrumbs"] = list(
-            map(lambda x: (x[0], x[1]), list(enumerate(breadcrumbs, start=1)))
+        context["breadcrumbs"] = build_breadcrumbs(
+            [
+                ["Admin", addressOfPages["adminMainPage"]],
+                ["API Docs", addressOfPages["APIDocs"]],
+            ]
         )
         return context
 
@@ -788,10 +725,7 @@ class APIDocs(SuperuserRequiredMixin, LoginRequiredMixin, View):
         return render(request, "adminpanel/apidocs.html", context)
 
 
-class GetQuestion(SuperuserRequiredMixin, LoginRequiredMixin, View):
-    login_url = "adminLogin"
-    raise_exception = False
-
+class GetQuestion(AdminViewBase):
     def get(self, request, *args, **kwargs):
         response = {}
         count = self.request.GET.get("count")
@@ -850,10 +784,12 @@ class AddQuestion(APIView):
             def checkDifficulty(diff):
                 difficulties = ("Easy", "Medium", "Hard")
                 db_difficulties = (Question.EASY, Question.MEDIUM, Question.HARD)
-                difficulties = list(map(lambda x: x.lower(), difficulties))
-                mapped_difficulties = dict(zip(difficulties, db_difficulties))
+                lower_difficulties = [difficulty.lower() for difficulty in difficulties]
+                mapped_difficulties = dict(
+                    zip(lower_difficulties, db_difficulties, strict=True)
+                )
                 if isinstance(diff, str):
-                    if diff.lower() in difficulties:
+                    if diff.lower() in lower_difficulties:
                         return mapped_difficulties[diff.lower()]
                 return False
 
@@ -880,10 +816,10 @@ class AddQuestion(APIView):
 
             keys = tuple(obj.keys())
             if (
-                (not "difficulty" in keys)
-                or (not "question" in keys)
-                or (not "correct_answer" in keys)
-                or (not "incorrect_answers" in keys)
+                "difficulty" not in keys
+                or "question" not in keys
+                or "correct_answer" not in keys
+                or "incorrect_answers" not in keys
             ):
                 queryResult["status_code"] = 4
                 queryResult["status_message"] = self.statuses[
@@ -941,11 +877,11 @@ class AddQuestion(APIView):
                 ]
                 add_questions.append(
                     (
-                        dict(
-                            text=qn,
-                            difficulty=difficulty,
-                            correct_option=correct_option,
-                        ),
+                        {
+                            "text": qn,
+                            "difficulty": difficulty,
+                            "correct_option": correct_option,
+                        },
                         cat,
                         incorrect_options,
                     )
@@ -981,19 +917,15 @@ class AddQuestion(APIView):
         for idx in range(len(received_json_data)):
             received_json_data[idx] = checkQuestion(received_json_data[idx])
 
-        status_codes_after_action = list(
-            res["status_code"] for res in received_json_data
-        )
+        status_codes_after_action = [res["status_code"] for res in received_json_data]
         if len(set(status_codes_after_action)) >= 1 and 1 not in set(
             status_codes_after_action
         ):
             final["success"] = 0
-            unique_status_codes = list(
-                map(
-                    lambda x: {"status_code": x, "status_message": self.statuses[x]},
-                    set(status_codes_after_action),
-                )
-            )
+            unique_status_codes = [
+                {"status_code": code, "status_message": self.statuses[code]}
+                for code in set(status_codes_after_action)
+            ]
             final["errors"] = unique_status_codes
             return JsonResponse(final, safe=False, encoder=QuestionEncoder, status=409)
 

--- a/adminpanel/viewsExtra.py
+++ b/adminpanel/viewsExtra.py
@@ -1,8 +1,9 @@
-from django.forms.widgets import CheckboxSelectMultiple
-from django.db.models.fields import BigAutoField, CharField
-from django.db import models
-import re
 import datetime
+import re
+
+from django.db import models
+from django.db.models.fields import BigAutoField, CharField
+from django.forms.widgets import CheckboxSelectMultiple
 
 
 # Useful functions
@@ -24,7 +25,7 @@ def pk_checker(pk: int | str, model: models.Model) -> bool:
         RANDOM_STRING_CHARS = (
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         )
-        pattern = "[{}]".format(RANDOM_STRING_CHARS) + "{8}"
+        pattern = f"[{RANDOM_STRING_CHARS}]" + "{8}"
         return re.fullmatch(pattern, pk) is not None
     else:
         return pk.isdigit()
@@ -35,11 +36,11 @@ def safe_pk_list_converter(pk_list: list, model: models.Model) -> list:
     Safely converts a string to number and 0 if not in digits to return a list of numbers.
     """
     if isinstance(model._meta.pk, BigAutoField):
-        return list(map(lambda x: int(x) if pk_checker(x, model) else 0, pk_list))
+        return [int(x) if pk_checker(x, model) else 0 for x in pk_list]
     elif isinstance(model._meta.pk, CharField):
-        return list(map(lambda x: x if pk_checker(x, model) else 0, pk_list))
+        return [x if pk_checker(x, model) else 0 for x in pk_list]
     else:
-        return list(map(lambda x: int(x) if pk_checker(x, model) else 0, pk_list))
+        return [int(x) if pk_checker(x, model) else 0 for x in pk_list]
 
 
 def widget_list_generator(model):

--- a/auth/admin.py
+++ b/auth/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/auth/models.py
+++ b/auth/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/auth/tests.py
+++ b/auth/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/auth/urls.py
+++ b/auth/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from . import views as authApp
 
 urlpatterns = [

--- a/auth/views.py
+++ b/auth/views.py
@@ -1,10 +1,13 @@
-from django.shortcuts import render, redirect, HttpResponseRedirect
-
-from django.contrib import messages
+from django.contrib import auth, messages
 from django.contrib.auth.models import User
+from django.shortcuts import redirect, render
 
-from django.contrib import auth
-from .validate import *
+from .validate import (
+    confirmPassword,
+    emailValidator,
+    passwordValidator,
+    usernameValidator,
+)
 
 
 def register(request):
@@ -29,9 +32,7 @@ def register(request):
             if User.objects.filter(username=username).exists():
                 messages.warning(request, "You already have an account.")
                 return redirect("login")
-            newuser = User.objects.create_user(
-                username=username, email=email, password=password
-            )
+            User.objects.create_user(username=username, email=email, password=password)
             messages.success(request, "Account successfully created!")
             return redirect("login")
         else:

--- a/game/admin.py
+++ b/game/admin.py
@@ -1,5 +1,15 @@
 from django.contrib import admin
-from .models import *
+
+from .models import (
+    Category,
+    ChosenOption,
+    Level,
+    Lifeline,
+    Option,
+    Question,
+    QuestionOrder,
+    Session,
+)
 
 # Register your models here.
 admin.site.register(Lifeline)

--- a/game/management/commands/_private.py
+++ b/game/management/commands/_private.py
@@ -1,14 +1,14 @@
-import asyncio, aiohttp, itertools
+import itertools
 from html import unescape
 
-difficulty_choices = list(
-    (
-        "".join(x)
-        for x in itertools.chain.from_iterable(
-            itertools.permutations("emh", r) for r in range(1, len("emh") + 1)
-        )
+import aiohttp
+
+difficulty_choices = [
+    "".join(x)
+    for x in itertools.chain.from_iterable(
+        itertools.permutations("emh", r) for r in range(1, len("emh") + 1)
     )
-)  # regex : (?:([emh])(?!.*\1))+
+]  # regex : (?:([emh])(?!.*\1))+
 
 
 async def html_get(url):

--- a/game/management/commands/addquestions.py
+++ b/game/management/commands/addquestions.py
@@ -1,10 +1,13 @@
-import json, logging
+import json
+import logging
 from itertools import islice
-from django.core.management.base import BaseCommand
-from django.core.exceptions import ImproperlyConfigured
-from game.models import Question, Option, Category
-from django.utils import timezone
+
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from game.models import Category, Option, Question
 
 
 def configure_logger(enable_logging):
@@ -55,9 +58,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        def lazy_list_generator(l):
-            for obj in l:
-                yield obj
+        def lazy_list_generator(iterable):
+            yield from iterable
 
         json_file = options["json_file"]
         enable_logging = options.get("enable_logging", False)
@@ -67,12 +69,14 @@ class Command(BaseCommand):
         self.logger = configure_logger(enable_logging)
 
         try:
-            with open(json_file, "r", encoding="utf-8") as file:
+            with open(json_file, encoding="utf-8") as file:
                 data = json.load(file)
         except FileNotFoundError:
-            raise ImproperlyConfigured(f"File '{json_file}' not found.")
+            raise ImproperlyConfigured(f"File '{json_file}' not found.") from None
         except json.JSONDecodeError:
-            raise ImproperlyConfigured(f"File '{json_file}' is not a valid JSON file.")
+            raise ImproperlyConfigured(
+                f"File '{json_file}' is not a valid JSON file."
+            ) from None
 
         user = get_user_model().objects.get(username="admin")
         questions_to_create = []
@@ -168,7 +172,7 @@ incorrect_answers={item['incorrect_answers']}"
                 filter(lambda x: True if len(x["question"]) > 0 else False, data)
             )
 
-            for question, item in zip(questions_to_create, data):
+            for question, item in zip(questions_to_create, data, strict=True):
                 category = category_mapping[item["category"]]
                 question.falls_under.add(category)
                 question.incorrect_options.set(item["incorrect_answers"])

--- a/game/management/commands/createcategories.py
+++ b/game/management/commands/createcategories.py
@@ -1,12 +1,14 @@
-import asyncio, aiohttp
+import asyncio
 import logging
 from html import unescape
 from time import perf_counter
-from ._private import html_get
-from game.models import Category
-from django.utils import timezone
 
 from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from game.models import Category
+
+from ._private import html_get
 
 
 def configure_logger(enable_logging):
@@ -72,7 +74,7 @@ class Command(BaseCommand):
         start = perf_counter()
         categories = asyncio.run(self._category_lookup())
         end = perf_counter()
-        msg = f"Categories retrieved in {end-start} seconds."
+        msg = f"Categories retrieved in {end - start} seconds."
         self.logger.info(msg)
         self.stdout.write(self.style.SUCCESS(msg))
 
@@ -104,6 +106,6 @@ class Command(BaseCommand):
                     )
 
         end = perf_counter()
-        msg = f"Categories created/updated in {end-start} seconds."
+        msg = f"Categories created/updated in {end - start} seconds."
         self.logger.info(msg)
         self.stdout.write(self.style.SUCCESS(msg))

--- a/game/management/commands/createlevels.py
+++ b/game/management/commands/createlevels.py
@@ -1,8 +1,9 @@
 import logging
 from time import perf_counter
-from game.models import Level
 
 from django.core.management.base import BaseCommand
+
+from game.models import Level
 
 
 def configure_logger(enable_logging):
@@ -91,6 +92,6 @@ class Command(BaseCommand):
                 count += 1
 
         end = perf_counter()
-        msg = f"{count} levels created in {end-start} seconds."
+        msg = f"{count} levels created in {end - start} seconds."
         self.logger.info(msg)
         self.stdout.write(self.style.SUCCESS(msg))

--- a/game/management/commands/createlifelines.py
+++ b/game/management/commands/createlifelines.py
@@ -1,8 +1,9 @@
 import logging
 from time import perf_counter
-from game.models import Lifeline
 
 from django.core.management.base import BaseCommand
+
+from game.models import Lifeline
 
 
 def configure_logger(enable_logging):
@@ -86,6 +87,6 @@ class Command(BaseCommand):
                 count += 1
 
         end = perf_counter()
-        msg = f"{count} lifelines created in {end-start} seconds."
+        msg = f"{count} lifelines created in {end - start} seconds."
         self.logger.info(msg)
         self.stdout.write(self.style.SUCCESS(msg))

--- a/game/management/commands/extractoptions.py
+++ b/game/management/commands/extractoptions.py
@@ -1,7 +1,10 @@
-import json, logging
+import json
+import logging
 from itertools import islice
-from django.core.management.base import BaseCommand
+
 from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
 from game.models import Option
 
 
@@ -48,8 +51,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         def lazy_option_generator(options):
-            for option in options:
-                yield option
+            yield from options
 
         json_file = options["json_file"]
         enable_logging = options.get("enable_logging", False)
@@ -58,12 +60,14 @@ class Command(BaseCommand):
         self.logger = configure_logger(enable_logging)
 
         try:
-            with open(json_file, "r", encoding="utf-8") as file:
+            with open(json_file, encoding="utf-8") as file:
                 data = json.load(file)
         except FileNotFoundError:
-            raise ImproperlyConfigured(f"File '{json_file}' not found.")
+            raise ImproperlyConfigured(f"File '{json_file}' not found.") from None
         except json.JSONDecodeError:
-            raise ImproperlyConfigured(f"File '{json_file}' is not a valid JSON file.")
+            raise ImproperlyConfigured(
+                f"File '{json_file}' is not a valid JSON file."
+            ) from None
 
         unique_options = set()
 

--- a/game/management/commands/fetchqns.py
+++ b/game/management/commands/fetchqns.py
@@ -1,10 +1,14 @@
-import asyncio, aiohttp, random, json
+import asyncio
+import json
 import logging
+import random
 from html import unescape
 from time import perf_counter, time
-from ._private import difficulty_choices, html_get
 
+import aiohttp
 from django.core.management.base import BaseCommand
+
+from ._private import difficulty_choices, html_get
 
 
 def configure_logger(enable_logging, log_to_file):
@@ -46,8 +50,8 @@ class Command(BaseCommand):
             "h": "hard",
         }
         self._difficulty_choices = difficulty_choices
-        self._categories = list(x for x in range(9, 32 + 1)) + ["any"]
-        self._categories_cli = list(str(x) for x in range(9, 32 + 1)) + ["any"]
+        self._categories = list(range(9, 32 + 1)) + ["any"]
+        self._categories_cli = [str(x) for x in range(9, 32 + 1)] + ["any"]
         self._category_text = '9-32 (both inclusive) or "any"'
         self.logger = None
 
@@ -128,7 +132,9 @@ class Command(BaseCommand):
                     else args[0]
                 )
 
-            kv = "&".join(["=".join(i) for i in list(zip(parameters, args))])
+            kv = "&".join(
+                ["=".join(i) for i in list(zip(parameters, args, strict=True))]
+            )
             return "https://opentdb.com/api.php?" + kv
 
         return generator
@@ -169,7 +175,7 @@ class Command(BaseCommand):
                         cat_id = int(api_url.split("category=")[-1].split("&")[0])
                         retrieved_categories.append(categories[cat_id])
                     list_of_qns = list(result["results"])
-                    list_of_qns = map(lambda q: unescape_question(q), list_of_qns)
+                    list_of_qns = (unescape_question(q) for q in list_of_qns)
                     responses.extend(list_of_qns)
 
                 await asyncio.sleep(5)  # Wait 5 seconds between requests
@@ -184,14 +190,14 @@ class Command(BaseCommand):
         query_coroutines = [
             GET_query_generator(a, b, c, d)
             for a, b, c, d in list(
-                zip(amount, category, difficulty, ["multiple"] * queries)
+                zip(amount, category, difficulty, ["multiple"] * queries, strict=False)
             )
         ]
 
         start = perf_counter()
         query_links = await asyncio.gather(*query_coroutines)
         end = perf_counter()
-        msg = f"Questions generated in {end-start} seconds."
+        msg = f"Questions generated in {end - start} seconds."
         self.logger.info(msg)
         self.stderr.write(self.style.SUCCESS(msg))
 
@@ -201,7 +207,7 @@ class Command(BaseCommand):
         with open(filename, "w") as f:
             json.dump(responses, f, indent=4)
         end = perf_counter()
-        msg = f"Questions fetched in {end-start} seconds."
+        msg = f"Questions fetched in {end - start} seconds."
         self.logger.info(msg)
         self.stderr.write(self.style.SUCCESS(msg))
         self.stdout.write(filename, ending="")
@@ -284,9 +290,7 @@ class Command(BaseCommand):
         amount = list(range(10, 20)) if (amount == 0) else [amount]
 
         category = (
-            self._categories
-            if (category == "any")
-            else list(map(lambda x: int(x), category))
+            self._categories if (category == "any") else [int(x) for x in category]
         )
 
         difficulty = (

--- a/game/models.py
+++ b/game/models.py
@@ -156,7 +156,10 @@ class Question(models.Model):
             text="None",
             correct_option_id=default_option_pk,
         )
-        if created or not question.incorrect_options.filter(pk=default_option_pk).exists():
+        if (
+            created
+            or not question.incorrect_options.filter(pk=default_option_pk).exists()
+        ):
             question.incorrect_options.add(default_option_pk)
         return question.pk
 

--- a/game/templatetags/utility.py
+++ b/game/templatetags/utility.py
@@ -21,7 +21,7 @@ def getListFromQueryDict(querydict, itemToGet):
 
 @register.filter()
 def querysetToPrimaryKey(queryset):
-    return list(map(lambda x: x.pk, queryset))
+    return [x.pk for x in queryset]
 
 
 @register.filter

--- a/game/tests.py
+++ b/game/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/kbc/settings.py
+++ b/kbc/settings.py
@@ -1,7 +1,8 @@
-from configurations import Configuration, values
-from pathlib import Path
 import os
+from pathlib import Path
 from shutil import which
+
+from configurations import Configuration, values
 
 
 class Base(Configuration):

--- a/kbc/urls.py
+++ b/kbc/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
     path("djadmin/", admin.site.urls),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,5 @@
 import pytest
+
 from game.models import Lifeline
 
 

--- a/tests/unit/test_admin_crud.py
+++ b/tests/unit/test_admin_crud.py
@@ -1,0 +1,106 @@
+import pytest
+from django.core.paginator import Page
+from django.test import RequestFactory
+from django.urls import reverse
+
+from adminpanel.crud import (
+    build_breadcrumbs,
+    get_record,
+    load_instance,
+    paginate,
+    record_context,
+)
+from adminpanel.views import AdminDBObjectChange, AdminDBObjectCreate
+from game.models import Category
+
+
+class TestPaginate:
+    def test_returns_requested_page(self):
+        page = paginate(list(range(30)), 2, per_page=10)
+
+        assert isinstance(page, Page)
+        assert page.number == 2
+        assert list(page.object_list) == list(range(10, 20))
+
+    def test_non_integer_page_falls_back_to_first(self):
+        page = paginate(list(range(30)), "abc", per_page=10)
+
+        assert page.number == 1
+
+    def test_out_of_range_page_falls_back_to_last(self):
+        page = paginate(list(range(30)), 99, per_page=10)
+
+        assert page.number == 3
+
+
+class TestBuildBreadcrumbs:
+    def test_enumerates_items_starting_at_one(self):
+        items = [["Admin", "/admin/"], ["Logs", "/admin/logs/"]]
+
+        assert build_breadcrumbs(items) == [
+            (1, ["Admin", "/admin/"]),
+            (2, ["Logs", "/admin/logs/"]),
+        ]
+
+
+@pytest.mark.django_db
+class TestRecordContext:
+    def test_builds_verbose_names_and_merges_kwargs(self):
+        context = record_context(Category, {"db": "category"}, allRecords=None)
+
+        assert context["recordVerboseName"] == Category._meta.verbose_name
+        assert context["recordVerboseNamePlural"] == Category._meta.verbose_name_plural
+        assert context["db"] == "category"
+        assert context["allRecords"] is None
+
+
+@pytest.mark.django_db
+class TestLoadInstance:
+    def test_loads_instance_from_numeric_string_pk(self):
+        category = Category.objects.create(name="General")
+
+        assert load_instance(Category, str(category.pk)) == category
+
+
+@pytest.mark.django_db
+class TestGetRecord:
+    def test_returns_record_when_pk_exists(self):
+        category = Category.objects.create(name="General")
+
+        assert get_record(Category, str(category.pk)) == category
+
+    def test_falls_back_to_first_record_when_pk_missing(self):
+        category = Category.objects.create(name="General")
+
+        assert get_record(Category, 999) == category
+
+
+@pytest.mark.django_db
+class TestFormStateMixin:
+    def test_create_form_kwargs_include_post_data_but_no_instance(self):
+        view = AdminDBObjectCreate()
+        view.request = RequestFactory().post(
+            reverse("adminDBObjectCreate", kwargs={"db": "category"})
+        )
+        view.kwargs = {"db": "category"}
+        view.set_form_class("category")
+
+        form_kwargs = view.get_form_kwargs()
+
+        assert form_kwargs["initial"] == {}
+        assert "data" in form_kwargs
+        assert "instance" not in form_kwargs
+
+    def test_change_form_kwargs_include_bound_instance(self):
+        category = Category.objects.create(name="General")
+        view = AdminDBObjectChange()
+        view.request = RequestFactory().get(
+            reverse("adminDBObject", kwargs={"db": "category", "pk": category.pk})
+        )
+        view.kwargs = {"db": "category", "pk": str(category.pk)}
+        view.set_form_state(Category, "category", str(category.pk))
+
+        form_kwargs = view.get_form_kwargs()
+
+        assert form_kwargs["instance"] == category
+        assert "data" not in form_kwargs

--- a/tests/unit/test_auth_views.py
+++ b/tests/unit/test_auth_views.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from django.urls import reverse
 
-
 REGISTER_URL = "/auth/register/"
 ADMINLOGIN_URL = "/auth/admin-login/"
 LOGIN_URL = "/auth/login/"
@@ -61,7 +60,9 @@ class TestRegisterView:
         assert any(m.level_tag == "error" for m in msgs)
 
     def test_mismatched_passwords(self, client):
-        response = client.post(REGISTER_URL, _valid_post_data(password2="differentPass1"))
+        response = client.post(
+            REGISTER_URL, _valid_post_data(password2="differentPass1")
+        )
         assert response.status_code == 302
         assert response.url == "/auth/register/"
         msgs = list(get_messages(response.wsgi_request))
@@ -70,7 +71,9 @@ class TestRegisterView:
     def test_password_contains_username(self, client):
         response = client.post(
             REGISTER_URL,
-            _valid_post_data(username="john", password="johnsmith1", password2="johnsmith1"),
+            _valid_post_data(
+                username="john", password="johnsmith1", password2="johnsmith1"
+            ),
         )
         assert response.status_code == 302
         assert response.url == "/auth/register/"
@@ -106,7 +109,9 @@ class TestAdminLoginView:
         assert response.url == reverse("adminMainPage")
 
     def test_authenticated_non_superuser_get_redirects_to_mainpage(self, client):
-        user = User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
+        user = User.objects.create_user(
+            **_valid_admin_data(username="regularuser", password="userPass1")
+        )
         client.force_login(user)
         response = client.get(ADMINLOGIN_URL)
         assert response.status_code == 302
@@ -119,14 +124,24 @@ class TestAdminLoginView:
         assert response.url == reverse("adminMainPage")
 
     def test_post_valid_non_superuser_credentials_redirects_to_mainpage(self, client):
-        User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
-        response = client.post(ADMINLOGIN_URL, _valid_admin_data(username="regularuser", password="userPass1"))
+        User.objects.create_user(
+            **_valid_admin_data(username="regularuser", password="userPass1")
+        )
+        response = client.post(
+            ADMINLOGIN_URL,
+            _valid_admin_data(username="regularuser", password="userPass1"),
+        )
         assert response.status_code == 302
         assert response.url == reverse("mainpage")
 
     def test_post_invalid_credentials_redirects_with_error(self, client):
-        User.objects.create_user(**_valid_admin_data(username="regularuser", password="userPass1"))
-        response = client.post(ADMINLOGIN_URL, _valid_admin_data(username="regularuser", password="wrongpass"))
+        User.objects.create_user(
+            **_valid_admin_data(username="regularuser", password="userPass1")
+        )
+        response = client.post(
+            ADMINLOGIN_URL,
+            _valid_admin_data(username="regularuser", password="wrongpass"),
+        )
         assert response.status_code == 302
         assert response.url == reverse("adminLogin")
         msgs = list(get_messages(response.wsgi_request))
@@ -197,7 +212,9 @@ class TestLoginView:
 
     def test_already_authenticated_get(self, client):
         data = _valid_login_data()
-        user = User.objects.create_user(username=data["username"], password=data["password"])
+        user = User.objects.create_user(
+            username=data["username"], password=data["password"]
+        )
         client.force_login(user)
         response = client.get(LOGIN_URL)
         assert response.status_code == 200


### PR DESCRIPTION
Fixes [TRI-80](https://linear.app/trivivo/issue/TRI-80/refactor-adminpanel-views-and-crud-infrastructure)

### Description

Refactors the admin panel view layer into reusable CRUD and presentation components without changing admin behavior or API contracts:

- New `adminpanel/crud.py` with shared helpers: `paginate`, `build_breadcrumbs`, `record_context`, `load_instance`, `get_record`
- New `AdminViewBase` (access control + `redirect_back`) and `FormStateMixin` (shared form-state handling for create/change views), removing duplicated form plumbing
- De-duplicated pagination, breadcrumb, model-registry lookup, and redirect logic across list, create, change, delete, history, dashboard, and API-access views
- Split `AdminListDB.post` bulk-delete condition into a focused, testable method
- Access control, admin audit logging, messages, templates, redirects, and API response formats are unchanged

Also resolves the pre-existing repo-wide ruff lint debt (auth, game management commands, templates, settings) so `make check` passes, and makes the `check` Make target source `.env` like `test` does. The security/perf changes from TRI-37 and TRI-38 are in the lower PRs of this stack; the TRI-40 thread-safety work already on main was not touched.

### Tests

- New `tests/unit/test_admin_crud.py`: focused tests for `paginate`, `build_breadcrumbs`, `record_context`, `load_instance`, `get_record`, and `FormStateMixin`
- Existing admin view/API suites all pass unchanged (redirects, log entries, messages, query budget)
- Full suite: 141 passed; `make check` passes
